### PR TITLE
[WIP] - Add basic docs

### DIFF
--- a/__tests__/__snapshots__/docs.test.js.snap
+++ b/__tests__/__snapshots__/docs.test.js.snap
@@ -108,76 +108,15 @@ exports[`Testing Docs Renders! 1`] = `
       </nav>
     </div>
     <div
-      className="css-2y5bqi"
+      className="css-gs4t34"
     >
       <div
-        className="css-1nvbmsg"
-      >
-        <div
-          className="css-17186zx"
-        >
-          <div
-            className="css-cuyszr"
-          >
-            {
-            <div
-              className="css-ehn2ke"
-            >
-              <svg
-                enableBackground="new 0 0 64 64"
-                viewBox="0 0 64 64"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="#ED4C5C"
-                >
-                  <path
-                    d="M20.8 6.4 40.9 26.5 29.7 37.7 2.2 10.2z"
-                  />
-                  <path
-                    d="m10.6 5.8c-5.2.9-9 2.7-8.6 4.1.5 1.4 5.1 1.8 10.4.9 5.2-1 9.1-2.8 8.6-4.2-.5-1.4-5.2-1.7-10.4-.8"
-                  />
-                </g>
-                <path
-                  d="m10.8 5.8c-4.9.8-8.5 2.6-8 3.9.5 1.3 4.8 1.6 9.7.8 4.9-.8 8.5-2.6 8-3.8-.5-1.4-4.8-1.8-9.7-.9"
-                  fill="#ff8080"
-                />
-                <path
-                  d="m22.6 16.5h18.2v23.8h-18.2z"
-                  fill="#e8e8e8"
-                  transform="matrix(.7071-.7071.7071.7071-10.7928 30.6765)"
-                />
-                <path
-                  d="m43.7 47h19v5.9h-19z"
-                  fill="#555b61"
-                  transform="matrix(.707-.7072.7072.707-19.7271 52.2523)"
-                />
-                <path
-                  d="m27.2 30.7h19v5.5h-19z"
-                  fill="#b2c1c0"
-                  transform="matrix(.7069-.7073.7073.7069-12.8952 35.7644)"
-                />
-                <path
-                  d="m34.8 29.8h21v24.4h-21z"
-                  fill="#3e4347"
-                  transform="matrix(.7071-.7071.7071.7071-16.45 44.3334)"
-                />
-              </svg>
-            </div>
-            }
-          </div>
-          <div
-            className="css-6l3qzw"
-          >
-            glamorous
-          </div>
-        </div>
-      </div>
-      <p
-        className="css-nil"
-      >
-        edit in pages/docs.js
-      </p>
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "",
+          }
+        }
+      />
     </div>
     <footer
       className="css-kv69lr"

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,0 +1,908 @@
+## Installation
+
+This module is distributed via [npm][npm] which is bundled with [node][node] and
+should be installed as one of your project's `dependencies`:
+
+```
+npm install --save glamorous
+```
+
+This also depends on `react` and `glamor` so you'll need those in your project
+as well (if you don't already have them):
+
+```
+npm install --save react glamor
+```
+
+> NOTE: If you're using React v15.5 or greater, you'll also need to have
+> `prop-types` installed: `npm install --save prop-types`
+
+You can then use one of the module formats:
+
+- `main`: `dist/glamorous.cjs.js` - exports itself as a CommonJS module
+- `global`: `dist/glamorous.umd.js` and `dist/glamorous.umd.min.js` - exports
+  itself as a [umd][umd] module which is consumable in several environments, the
+  most notable as a global.
+- `jsnext:main` and `module`: `dist/glamorous.es.js` - exports itself using the
+  ES modules specification, you'll need to configure webpack to make use of this
+  file do this using the [resolve.mainFields][mainFields] property.
+
+The most common use-case is consuming this module via CommonJS:
+
+```javascript
+const glamorous = require('glamorous')
+const {ThemeProvider} = glamorous
+// etc.
+```
+
+If you're transpiling (and/or using the `jsnext:main`):
+
+```javascript
+import glamorous, {ThemeProvider} from 'glamorous'
+
+// you can also import specific Glamorous Components (see section below on "Built-in" components)
+import {Div, H2} from 'glamorous'
+
+// tags with the same name as built-in JavaScript objects are importable with a Tag suffix
+// and tag names that contain dashes are transformed to CamelCase
+import {MapTag, ColorProfile} from 'glamorous'
+```
+
+If you want to use the global:
+
+```html
+<!-- Load dependencies -->
+<script src="https://unpkg.com/react/dist/react.js"></script>
+<script src="https://unpkg.com/prop-types/prop-types.js"></script>
+<script src="https://unpkg.com/glamor/umd/index.js"></script>
+<!-- load library -->
+<script src="https://unpkg.com/glamorous/dist/glamorous.umd.js"></script>
+<script>
+// Use window.glamorous here...
+const glamorous = window.glamorous
+const {ThemeProvider} = glamorous
+</script>
+```
+
+### React Native
+
+`glamorous` offers a version for React Native projects called `glamorous-native`.
+
+```js
+npm install glamorous-native --save
+```
+
+You can learn more at the [glamorous-native project][glamorous-native].
+
+### Typescript
+
+`glamorous` includes typescript definition files.
+
+For usage notes and known issues see [other/TYPESCRIPT_USAGE.md][typescript-usage].
+
+## Video Intro :tv:
+
+<a href="https://youtu.be/lmrQTpJ_3PM" title="glamorous walkthrough">
+  <img src="https://github.com/paypal/glamorous/raw/master/other/glamorous-walkthrough.png" alt="Video Screenshot" title="Video Screenshot" width="700" />
+</a>
+
+## Terms and concepts
+
+### glamorous
+
+The `glamorous` function is the main (only) export. It allows you to create
+glamorous components that render the styles to the component you give it. This
+is done by forwarding a `className` prop to the component you tell it to render.
+But before we get into how you wrap custom components, let's talk about the
+built-in DOM components.
+
+#### built-in DOM component factories
+
+For every DOM element, there is an associated `glamorous` component factory
+attached to the `glamorous` function. As above, you can access these factories
+like so: `glamorous.div`, `glamorous.a`, `glamorous.article`, etc.
+
+```jsx
+const MyStyledSection = glamorous.section({ margin: 1 })
+
+<MyStyledSection>content</MyStyledSection>
+// rendered output: <section class="<glamor-generated-class>">content</section>
+// styles applied: {margin: 1}
+```
+
+#### glamorousComponentFactory
+
+Whether you create one yourself or use one of the built-in ones mentioned above,
+each `glamorousComponentFactory` allows you to invoke it with styles and it
+returns you a new component which will have those styles applied when it's
+rendered. This is accomplished by generating a `className` for the styles you
+give and forwarding that `className` onto the rendered element. So if you're
+wrapping a component you intend to style, you'll need to make sure you accept
+the `className` as a prop and apply it to where you want the styles applied in
+your custom component (normally the root element).
+
+```jsx
+const UnstyledComp = ({ className, children }) => <div className={`${className} other-class`}>{children}</div>
+const MyStyledComp = glamorous(UnstyledComp)({ margin: 1 })
+
+<MyStyledComp>content</MyStyledComp>
+// rendered output: <div class="<glamor-generated-class> other-class">content</div>
+// styles applied: {margin: 1}
+```
+
+##### ...styles
+
+The `glamorousComponentFactory` accepts any number of style object arguments.
+These can be style objects or functions which are invoked with `props` on every
+render and return style objects. To learn more about what these style objects
+can look like, please take a look at the [`glamor`][glamor] documentation.
+
+```jsx
+const MyStyledDiv = glamorous.div(
+  {
+    margin: 1,
+  },
+  (props) => ({
+    padding: props.noPadding ? 0 : 4,
+  })
+)
+
+<MyStyledDiv /> // styles applied: {margin: 1, padding: 4}
+<MyStyledDiv noPadding /> // styles applied: {margin: 1, padding: 0}
+```
+
+> Tip: glamorous simply takes these style objects and forwards them to `glamor`.
+> `glamor` will then merge those together in a way you would expect. One neat
+> thing you can do is specify an array of style objects and `glamor` will treat
+> that exactly the same. It's really expressive! See the [examples][examples]
+> for an example of how this works.
+
+You can also specify other classes you'd like applied to the component as well.
+If these classes are generated by glamor, then their styles will be merged with
+the glamor style's, otherwise the class name will simply be forwarded. For
+example:
+
+```jsx
+const className1 = glamor.css({paddingTop: 1, paddingRight: 1}).toString()
+const styles2 = {paddingRight: 2, paddingBottom: 2}
+const className3 = glamor.css({paddingBottom: 3, paddingLeft: 3}).toString()
+const styles4 = {paddingLeft: 4}
+const MyStyledDiv = glamorous.div(
+  className1,
+  styles2,
+  className3,
+  styles4,
+  'extra-thing',
+)
+<MyStyledDiv /> // styles applied: {padding-top: 1, padding-right: 2, padding-bottom: 3, padding-left: 4} and anything coming from `extra-thing`.
+```
+
+#### GlamorousComponent
+
+The `GlamorousComponent` is what is returned from the `glamorousComponentFactory`.
+Its job is to get all the styles together, get a `className` (from [`glamor`][glamor])
+and forward that on to your component.
+
+##### supported props
+
+By default `GlamorousComponent` supports three props: `className`, `css` and `theme`
+which are used to override the styles of the component in different scenarios. For a
+more detailed explanation see [Overriding component styles](#overriding-component-styles) and [Theming](#theming) sections below.
+
+##### `innerRef`
+
+This is a function and if provided, will be called with the inner element's
+reference.
+
+```jsx
+const MyDiv = glamorous.div({ padding: 20 })
+
+// You can get a reference to the inner element with the `innerRef` prop
+class MyComponent extends React.Component {
+  render () {
+    return (
+      <MyDiv innerRef={c => this._divRef = c} />
+    )
+  }
+}
+```
+
+##### other props
+
+Only props that are safe to forward to the specific `element` (ie. that will
+ultimately be rendered) will be forwarded. So this is totally legit:
+
+```jsx
+<MyStyledDiv size="big" />
+```
+
+A use case for doing something like this would be for dynamic styles:
+
+```javascript
+const staticStyles = {color: 'green'}
+const dynamicStyles = props => ({fontSize: props.size === 'big' ? 32 : 24})
+const MyDynamicallyStyledDiv = glamorous.div(staticStyles, dynamicStyles)
+```
+
+> The exception to this prop forwarding is the pre-created `GlamorousComponent`s
+> (see below).
+
+#### built-in GlamorousComponents
+
+Often you want to style something without actually giving it a name (because
+naming things is hard). So glamorous also exposes a pre-created
+`GlamorousComponent` for each DOM node type which makes this reasonable to do:
+
+```jsx
+const { Div, Span, A, Img } = glamorous
+
+function MyUserInterface({name, tagline, imageUrl, homepage, size}) {
+  const nameSize = size
+  const taglineSize = size * 0.5
+  return (
+    <Div display="flex" flexDirection="column" justifyContent="center">
+      <A href={homepage} textDecoration="underline" color="#336479">
+        <Img borderRadius="50%" height={180} src={imageUrl} />
+        <Div fontSize={nameSize} fontWeight="bold">{name}</Div>
+      </A>
+      <Span fontSize={taglineSize} color="#767676">
+        {tagline}
+      </Span>
+    </Div>
+  )
+}
+```
+
+> Try this out in your browser [here](https://codesandbox.io/s/wmRo8OKDm)!
+
+Having to name all of that stuff could be tedious, so having these pre-built
+components is handy. The other handy bit here is that the props _are_ the styles
+for these components. Notice that glamorous can distinguish between props that
+are for styling and those that are have semantic meaning (like with the `Img`
+and `A` components which make use of `src` and `href` props).
+
+The `css` prop can be used to provide styles as an object.
+
+```jsx harmony
+import glamorous, {withTheme} from 'glamorous'
+const { Div, Span } = glamorous
+
+const predefinedStyle = {
+  color: '#767676',
+  fontSize: 18,
+}
+
+const MyUserInterface = withTheme(function ({tagline, theme}) {
+  return (
+    <Div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        [theme.mq.tablet]: {
+          flexDirection: 'row'
+        }
+      }}
+     >
+      <Span css={predefinedStyle}>
+        {tagline}
+      </Span>
+    </Div>
+  )
+})
+```
+
+One other tip... This totally works:
+
+```jsx
+<glamorous.Div color="blue">
+  JSX is pretty wild!
+</glamorous.Div>
+```
+
+#### Overriding component styles
+
+The most common scenario for using props is to override the style of an
+existing component (generated by `glamorous` or not). That can be achieved
+by using the props `className`, `css` and `theme` or simply component
+composition with the `glamorous()` function.
+
+If you're interested in knowing more about using the `theme` prop, see the
+[Theming](#theming) section instead for a more detailed explanation. In this
+section we'll explain how to use `className`, `css` and composition to override
+the styles of a component.
+
+Let's see how that can be done in the examples below.
+
+> Try this out in your browser [here](https://codesandbox.io/s/Kro5369wG)!
+
+We'll use this as our `GlamorousComponent`:
+
+```javascript
+const MyStyledDiv = glamorous.div({margin: 1, fontSize: 1, padding: 1})
+```
+
+##### using `className`
+
+For each `className` you provide, the `GlamorousComponent` will check to see
+whether it is a [`glamor`][glamor] generated `className` (can be from raw glamor
+or from `glamorous`, doesn't matter). If it is, it will get the original styles
+that were used to generate that `className` and merge those with the styles for
+the element that's rendered in a way that the provided `className`'s styles win
+in the event of a conflict.
+
+If the `className` is not generated by `glamor`, then it will simply be
+forwarded along with the `GlamorousComponent`-generated `className`.
+
+```jsx
+const myCustomGlamorStyles = glamor.css({fontSize: 2})
+<MyStyledDiv className={`${myCustomGlamorStyles} custom-class`} />
+// styles applied:
+// {margin: 1, fontSize: 2, padding: 1}
+// as well as any styles custom-class applies
+```
+
+##### using `css`
+
+This is an object and if provided, it will be merged with this component's and
+take highest priority over the component's predefined styles.
+
+```jsx
+const myCustomGlamorStyles = glamor.css({fontSize: 2, padding: 2})
+<MyStyledDiv
+  className={`${myCustomGlamorStyles} custom-class`}
+  css={{padding: 3}}
+/>
+// styles applied:
+// {margin: 1, fontSize: 2, padding: 3}
+// as well as any styles custom-class applies
+```
+
+##### using `glamorous()` composition
+
+If we just want to extend the styles of an existing component it can be done
+by using the `glamorous()` function.
+
+```jsx
+const MyComposedStyledDiv = glamorous(MyStyledDiv)({fontSize: 4, padding: 4})
+<MyComposedStyledDiv />
+// styles applied:
+// {margin: 1, fontSize: 4, padding: 4}
+```
+
+In fact, the built-in DOM component factories provided are just an abstraction
+of this function, so `glamorous.div` could be written as `glamorous('div')` instead.
+
+### glamorous API
+
+The `glamorous` function allows you to create your own
+`glamorousComponentFactory` (see [above](#glamorouscomponentfactory)) for any
+component you have. For [example](https://codesandbox.io/s/g5kDAyB9):
+
+```jsx
+const MyComponent = props => <div {...props} />
+const myGlamorousComponentFactory = glamorous(MyComponent)
+const MyGlamorousComponent = myGlamorousComponentFactory({/* styles */})
+
+<MyGlamorousComponent id="i-am-forwarded-to-the-div" />
+```
+
+You can also provide a few options to help glamorous know how to handle your
+component:
+
+#### displayName
+
+The `displayName` of a React component is used by React in the
+[React DevTools][react-devtools] and is really handy for debugging React
+applications. Glamorous will do its best to give a good `displayName` for your
+component, but, for the example above, the best it can do is:
+`glamorous(MyComponent)`. If you want to specify a `displayName`, you can do
+so with this property. For [example](https://codesandbox.io/s/P3Lyw5j2):
+
+```jsx
+const MyComponent = props => <div {...props} />
+const myGlamorousComponentFactory = glamorous(
+  MyComponent,
+  {displayName: 'MyGlamorousComponent'}
+)
+```
+
+And now all components created by the `myGlamorousComponentFactory` will have
+the `displayName` of `MyGlamorousComponent`.
+
+There is also a [babel plugin](https://www.npmjs.com/package/babel-plugin-glamorous-displayname) that can monkey-patch the `displayName` onto
+the components that you create from your component factory.
+
+
+#### rootEl
+
+React has an [Unknown Prop Warning][unknown-prop-warning] that it logs when you
+pass spurious props to DOM elements: (i.e. `<div big={true} />`). Because you
+can style your components using props, glamorous needs to filter out the props
+you pass so it doesn't forward these on to the underlying DOM element. However,
+if you create your own factory using a custom component, glamorous will just
+forward all the props (because the component may actually need them and
+glamorous has no way of knowing). But in some cases, the component may be
+spreading all of the props onto the root element that it renders. For these
+cases, you can tell glamorous which element is being rendered and glamorous will
+apply the same logic for which props to forward that it does for the built-in
+factories. For [example](https://codesandbox.io/s/P18oV4kD2):
+
+```jsx
+const MyComponent = props => <div {...props} />
+const myGlamorousComponentFactory = glamorous(
+  MyComponent,
+  {rootEl: 'div'}
+)
+
+const MyGlamorousComponent = myGlamorousComponentFactory(props => ({
+  fontSize: props.big ? 36 : 24,
+}))
+
+<MyGlamorousComponent big={true} id="room423" />
+// this will render:
+// <div id="room423" />
+// with {fontSize: 36}
+// `big` is not forwarded to MyComponent because the `rootEl` is a `div` and `big`
+// is not a valid attribute for a `div` however `id` will be forwarded because
+// `id` is a valid prop
+```
+
+#### forwardProps
+
+There are some cases where you're making a `glamorousComponentFactory` out of
+a custom component that spreads _some_ of the properties across an underlying
+DOM element, but not all of them. In this case you should use `rootEl` to
+forward only the right props to be spread on the DOM element, but you can also
+use `forwardProps` to specify extra props that should be forwarded. For
+[example](https://codesandbox.io/s/GZEo8jOyy):
+
+```jsx
+const MyComponent = ({shouldRender, ...rest}) => (
+  shouldRender ? <div {...rest} /> : null
+)
+const MyStyledComponent = glamorous(MyComponent, {
+  forwardProps: ['shouldRender'],
+  rootEl: 'div',
+})(props => ({
+  fontSize: props.big ? 36 : 24,
+}))
+<MyStyledComponent shouldRender={true} big={false} id="hello" />
+// this will render:
+// <div id="hello" />
+// with {fontSize: 24}
+// `shouldRender` will be forwarded to `MyComponent` because it is included in
+// `forwardProps`. `big` will not be forwarded to `MyComponent` because `rootEl`
+// is a `div` and that's not a valid prop for a `div`, but it will be used in
+// the styles object function that determines the `fontSize`. Finally `id` will
+// be forwarded to `MyComponent` because it is a valid prop for a `div`.
+```
+
+### Theming
+
+`glamorous` fully supports theming using a special `<ThemeProvider>` component.
+
+It provides the `theme` to all glamorous components down the tree.
+
+> Try this out in your browser [here](https://codesandbox.io/s/o2yq9MkQk)!
+
+```jsx
+import glamorous, {ThemeProvider} from 'glamorous'
+
+// our main theme object
+const theme = {
+  main: {color: 'red'}
+}
+
+// our secondary theme object
+const secondaryTheme = {
+  main: {color: 'blue'}
+}
+
+// a themed <Title> component
+const Title = glamorous.h1({
+  fontSize: '10px'
+}, (props, theme) => ({
+  color: theme.main.color
+}))
+
+// use <ThemeProvider> to pass theme down the tree
+<ThemeProvider theme={theme}>
+  <Title>Hello!</Title>
+</ThemeProvider>
+
+// it is possible to nest themes
+// inner themes will be merged with outers
+<ThemeProvider theme={theme}>
+  <div>
+    <Title>Hello!</Title>
+    <ThemeProvider theme={secondaryTheme}>
+      {/* this will be blue */}
+      <Title>Hello from here!</Title>
+    </ThemeProvider>
+  </div>
+</ThemeProvider>
+
+// to override a theme, just pass a theme prop to a glamorous component
+// the component will ignore any surrounding theme, applying the one passed directly via props
+<ThemeProvider theme={theme}>
+  {/* this will be yellow */}
+  <Title theme={{main: {color: 'yellow'}}}>Hello!</Title>
+</ThemeProvider>
+```
+
+`glamorous` also exports a `withTheme` higher order component (HOC) so you can access your theme in any component!
+> Try this out in your browser [here](https://codesandbox.io/s/qYmJjE4jy)!
+
+```jsx
+import glamorous, {ThemeProvider,  withTheme} from 'glamorous'
+
+// our main theme object
+const theme = {
+  main: {color: 'red'}
+}
+
+// a themed <Title> component
+const Title = glamorous.h1({
+  fontSize: '10px'
+}, (props, theme) => ({
+  color: theme.main.color
+}))
+
+// normal component that takes a theme prop
+const SubTitle = ({children, theme: {color}}) => (
+  <h3 style={{color}}>{children}</h3>
+)
+
+// extended component with theme prop
+const ThemedSubTitle = withTheme(SubTitle)
+
+<ThemeProvider theme={theme}>
+  <Title>Hello!</Title>
+  <ThemedSubTitle>from withTheme!</ThemedSubTitle>
+</ThemeProvider>
+```
+
+Or if you prefer decorator syntax:
+
+```jsx
+import React, {Component} from 'react'
+import glamorous, {ThemeProvider,  withTheme} from 'glamorous'
+
+// our main theme object
+const theme = {
+  main: {color: 'red'}
+}
+
+// a themed <Title> component
+const Title = glamorous.h1({
+  fontSize: '10px'
+}, (props, theme) => ({
+  color: theme.main.color
+}))
+
+// extended component with theme prop
+@withTheme
+class SubTitle extends Component {
+  render() {
+    const {children, theme: {main: {color}}} = this.props
+    return <h3 style={{color}}>{children}</h3>
+  }
+}
+
+<ThemeProvider theme={theme}>
+  <Title>Hello!</Title>
+  <SubTitle>from withTheme!</SubTitle>
+</ThemeProvider>
+```
+> `withTheme` expects a `ThemeProvider` further up the render tree and will warn in `development` if one is not found!
+
+### Context
+
+[context](https://facebook.github.io/react/docs/context.html) is an unstable
+API and it's not recommended to use it directly. However, if you need to use it
+for some reason, here's an example of how you could do that:
+
+```jsx
+const dynamicStyles = (props, theme, context) => ({
+  color: context.isLoggedIn ? 'green' : 'red'
+})
+const MyDiv = glamorous.div(dynamicStyles)
+MyDiv.contextTypes = {
+  isLoggedIn: PropTypes.string,
+}
+
+class Parent extends React.Component {
+  getChildContext() {
+    return {
+      isLoggedIn: true,
+    }
+  }
+  render() {
+    return <MyDiv />
+  }
+}
+
+Parent.childContextTypes = {
+  isLoggedIn: PropTypes.string,
+}
+
+<Parent />
+// renders <div />
+// with {color: 'green'}
+```
+
+### Size
+
+If your use case is really size constrained, then you might consider using the "tiny" version of glamorous for your application.
+It's is a miniature version of `glamorous` with a few limitations:
+
+1. No built-in component factories (`glamorous.article({/* styles */})`)
+   So you have to create your own (`glamorous('article')({/* styles */})`)
+2. No built-in glamorous components (`glamorous.Span`)
+3. No props filtering for dynamic styles, instead, you place them on a special
+   `glam` prop (see the example below).
+4. If you need `ThemeProvider` or `withTheme`, you must import those manually.
+   They are not exported as part of `glamorous/tiny` like they are with `glamorous`.
+
+Here's an example of what you're able to do with it.
+
+```jsx
+import React from 'react'
+import glamorous from 'glamorous/dist/glamorous.es.tiny'
+
+const Comp = glamorous('div')({
+  color: 'red'
+}, (props) => ({
+  fontSize: props.glam.big ? 20 : 12
+}))
+function Root() {
+  return (
+    <Comp
+      glam={{big: true}}
+      thisWillBeForwardedAndReactWillWarn
+    >
+      ciao
+    </Comp>
+  )
+}
+
+export default Root
+```
+
+It's recommended to use either [`babel-plugin-module-resolver`][babel-plugin-module-resolver]
+or the [`resolve.alias`][resolve-alias] config with webpack so you don't have
+to import from that full path. You have the following options available for this
+import:
+
+1. `glamorous/dist/glamorous.es.tiny.js` - use if you're using Webpack@>=2 or Rollup
+2. `glamorous/dist/glamorous.cjs.tiny` - use if you're not transpiling ESModules
+3. `glamorous/dist/glamorous.umd.tiny.js` - use if you're including it as a script tag. (There's also a `.min.js` version).
+
+The current size of `glamorous/dist/glamorous.umd.tiny.min.js` is: [![tiny size][tiny-size-badge]][unpkg-dist]
+[![tiny gzip size][tiny-gzip-badge]][unpkg-dist]
+
+> IMPORTANT NOTE ABOUT SIZE: Because `glamorous` depends on `glamor`, you should consider the full size you'll be adding
+> to your application if you don't already have `glamor`.
+> The current size of `glamor/umd/index.min.js` is: [![glamor size][glamor-size-badge]][unpkg-glamor]
+> [![glamor gzip size][glamor-gzip-badge]][unpkg-glamor]
+
+
+### Server Side Rendering (SSR)
+
+Because both `glamor` and `react` support SSR, `glamorous` does too! I actually
+do this on [my personal site](https://github.com/kentcdodds/kentcdodds.com)
+which is generated at build-time on the server. Learn about rendering
+[`react` on the server][react-ssr] and [`glamor` too][glamor-ssr].
+
+### Example Style Objects
+
+Style objects can affect pseudo-classes and pseudo-elements, complex CSS
+selectors, introduce keyframe animations, and use media queries:
+
+<details>
+<summary>pseudo-class</summary>
+
+```javascript
+const MyLink = glamorous.a({
+  ':hover': {
+    color: 'red'
+  }
+})
+
+// Use in a render function
+<MyLink href="https://github.com">GitHub</MyLink>
+```
+</details>
+
+<details>
+<summary>pseudo-element</summary>
+
+```jsx
+const MyListItem = glamorous.li({
+  listStyleType: 'none',
+  position: 'relative',
+  '&::before': {
+    content: `'#'`, // be sure the quotes are included in the passed string
+    display: 'block',
+    position: 'absolute',
+    left: '-20px',
+    width: '20px',
+    height: '20px'
+  }
+})
+// Use in a render function
+<ul>
+  <MyListItem>Item 1</MyListItem>
+  <MyListItem>Item 2</MyListItem>
+  <MyListItem>Item 3</MyListItem>
+</ul>
+```
+</details>
+
+<details>
+<summary>Relational CSS Selectors</summary>
+
+```jsx
+const MyDiv = glamorous.div({
+  display: 'block',
+  '& div': { color: 'red' }, // child selector
+  '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
+  '& > p': { color: 'blue' } // direct descendent
+})
+
+// Use in a render function
+<MyDiv>
+  <div><p>Red Underlined Paragraph</p></div>
+  <div>Red Paragraph</div>
+  <p>Blue Paragraph</p>
+</MyDiv>
+```
+</details>
+
+<details>
+<summary>Animations</summary>
+
+> Try this in [your browser](https://codesandbox.io/s/31VMyP7XO)
+
+```jsx
+// import css from glamor
+import { css } from 'glamor'
+
+// Define the animation styles
+const animationStyles = props => {
+  const bounce = css.keyframes({
+    '0%': { transform: `scale(1.01)` },
+    '100%': { transform: `scale(0.99)` }
+  })
+  return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
+}
+
+// Define the element
+const AnimatedDiv = glamorous.div(animationStyles)
+
+// Use in a render function
+<AnimatedDiv>
+  Bounce.
+</AnimatedDiv>
+```
+</details>
+
+<details>
+<summary>Media Queries</summary>
+
+```jsx
+const MyResponsiveDiv = glamorous.div({
+  width: '100%',
+  padding: 20,
+  '@media(min-width: 400px)': {
+    width: '85%',
+    padding: 0
+  }
+})
+// Use in a render function
+<MyResponsiveDiv>
+  Responsive Content
+</MyResponsiveDiv>
+```
+</details>
+
+## Users
+
+Who uses `glamorous`? See [other/USERS.md](https://github.com/paypal/glamorous/blob/master/other/USERS.md) and add yourself if you use `glamorous`!
+
+## Inspiration
+
+This package was inspired by the work from people's work on the following
+projects:
+
+- [styled-components](https://github.com/styled-components/styled-components)
+- [jsxstyle](https://github.com/smyte/jsxstyle)
+
+The biggest inspiration for building this is because I love the API offered by
+`styled-components`, but I wanted:
+
+1. Not to ship a CSS parser to the browser (because it's huge and less
+  performant).
+2. Support for RTL (via something like [rtl-css-js][rtl-css-js])
+3. Support for using _real_ JavaScript objects rather than a CSS string (better
+  tooling support, ESLint, etc.)
+
+> You can get around the parser issue if you use a certain babel plugin, but
+> then you can't do any dynamic construction of your CSS string (like
+> [this][styled-components-util]) which is a bummer for custom utilities.
+
+## Other Solutions
+
+There are actually quite a few solutions to the general problem of styling in
+React. This isn't the place for a full-on comparison of features, but I'm
+unaware of any which supports _all_ of the features which this library supports.
+
+## Support
+
+If you need help, please fork [this CodeSandbox][help-sandbox] and bring it up in
+[the chat][chat]
+
+## LICENSE
+
+MIT
+
+[npm]: https://www.npmjs.com/
+[node]: https://nodejs.org
+[build-badge]: https://img.shields.io/travis/paypal/glamorous.svg?style=flat-square
+[build]: https://travis-ci.org/paypal/glamorous
+[coverage-badge]: https://img.shields.io/codecov/c/github/paypal/glamorous.svg?style=flat-square
+[coverage]: https://codecov.io/github/paypal/glamorous
+[dependencyci-badge]: https://dependencyci.com/github/paypal/glamorous/badge?style=flat-square
+[dependencyci]: https://dependencyci.com/github/paypal/glamorous
+[version-badge]: https://img.shields.io/npm/v/glamorous.svg?style=flat-square
+[package]: https://www.npmjs.com/package/glamorous
+[downloads-badge]: https://img.shields.io/npm/dm/glamorous.svg?style=flat-square
+[npm-stat]: http://npm-stat.com/charts.html?package=glamorous&from=2017-04-01
+[license-badge]: https://img.shields.io/npm/l/glamorous.svg?style=flat-square
+[license]: https://github.com/paypal/glamorous/blob/master/LICENSE
+[prs-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
+[prs]: http://makeapullrequest.com
+[donate-badge]: https://img.shields.io/badge/$-support-green.svg?style=flat-square
+[donate]: http://kcd.im/donate
+[chat]: https://gitter.im/paypal/glamorous
+[chat-badge]: https://img.shields.io/gitter/room/paypal/glamorous.svg?style=flat-square
+[coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
+[coc]: https://github.com/paypal/glamorous/blob/master/other/CODE_OF_CONDUCT.md
+[roadmap-badge]: https://img.shields.io/badge/%F0%9F%93%94-roadmap-CD9523.svg?style=flat-square
+[roadmap]: https://github.com/paypal/glamorous/blob/master/other/ROADMAP.md
+[examples-badge]: https://img.shields.io/badge/%F0%9F%92%A1-examples-8C8E93.svg?style=flat-square
+[examples]: https://github.com/paypal/glamorous/blob/master/examples
+[github-watch-badge]: https://img.shields.io/github/watchers/paypal/glamorous.svg?style=social
+[github-watch]: https://github.com/paypal/glamorous/watchers
+[github-star-badge]: https://img.shields.io/github/stars/paypal/glamorous.svg?style=social
+[github-star]: https://github.com/paypal/glamorous/stargazers
+[twitter]: https://twitter.com/intent/tweet?text=Check%20out%20glamorous!%20https://github.com/paypal/glamorous%20%F0%9F%91%8D
+[twitter-badge]: https://img.shields.io/twitter/url/https/github.com/paypal/glamorous.svg?style=social
+[emojis]: https://github.com/kentcdodds/all-contributors#emoji-key
+[all-contributors]: https://github.com/kentcdodds/all-contributors
+[glamor]: https://github.com/threepointone/glamor
+[rtl-css-js]: https://github.com/kentcdodds/rtl-css-js
+[gzip-badge]: http://img.badgesize.io/https://unpkg.com/glamorous/dist/glamorous.umd.min.js?compression=gzip&label=gzip%20size&style=flat-square
+[size-badge]: http://img.badgesize.io/https://unpkg.com/glamorous/dist/glamorous.umd.min.js?label=size&style=flat-square
+[tiny-gzip-badge]: http://img.badgesize.io/https://unpkg.com/glamorous/dist/glamorous.umd.tiny.min.js?compression=gzip&label=gzip%20size&style=flat-square
+[tiny-size-badge]: http://img.badgesize.io/https://unpkg.com/glamorous/dist/glamorous.umd.tiny.min.js?label=size&style=flat-square
+[unpkg-dist]: https://unpkg.com/glamorous/dist/
+[glamor-gzip-badge]: http://img.badgesize.io/https://unpkg.com/glamor/umd/index.min.js?compression=gzip&label=gzip%20size&style=flat-square
+[glamor-size-badge]: http://img.badgesize.io/https://unpkg.com/glamor/umd/index.min.js?label=size&style=flat-square
+[unpkg-glamor]: https://unpkg.com/glamor/umd/
+[module-formats-badge]: https://img.shields.io/badge/module%20formats-umd%2C%20cjs%2C%20es-green.svg?style=flat-square
+[mainFields]: https://webpack.js.org/configuration/resolve/#resolve-mainfields
+[umd]: https://github.com/umdjs/umd
+[styled-components-util]: https://codepen.io/kentcdodds/pen/MpxMge
+[intro-blogpost]: https://medium.com/p/fb3c9f4ed20e
+[react-ssr]: https://facebook.github.io/react/docs/react-dom-server.html
+[glamor-ssr]: https://github.com/threepointone/glamor/blob/5e7d988211330b8e2fca5bb8da78e35051444efd/docs/server.md
+[help-sandbox]: http://kcd.im/glamorous-help
+[react-devtools]: https://github.com/facebook/react-devtools
+[babel-plugin]: https://github.com/paypal/glamorous/issues/29
+[unknown-prop-warning]: https://facebook.github.io/react/warnings/unknown-prop.html
+[babel-plugin-module-resolver]: https://github.com/tleunen/babel-plugin-module-resolver
+[resolve-alias]: https://webpack.js.org/configuration/resolve/#resolve-alias
+[glamorous-native]: https://github.com/robinpowered/glamorous-native
+[typescript-usage]: https://github.com/paypal/glamorous/blob/master/other/TYPESCRIPT_USAGE.md

--- a/next.config.js
+++ b/next.config.js
@@ -1,16 +1,31 @@
-// This file will let us add in prefetch conditionally so we don't break jest snapshot testing
-
 const webpack = require('webpack')
+const marked = require('marked')
 
+const renderer = new marked.Renderer()
 const USE_PREFETCH = process.env.NODE_ENV !== 'test'
 
 module.exports = {
   webpack: config => {
+    // Add in prefetch conditionally so we don't break jest snapshot testing
     config.plugins.push(
       new webpack.DefinePlugin({
         'process.env.USE_PREFETCH': JSON.stringify(USE_PREFETCH)
       })
     )
+
+    // Markdown loader so we can use docs as .md files
+    config.module.rules.push({
+      test: /\.md$/,
+      loader: 'html-loader'
+    })
+    config.module.rules.push({
+      test: /\.md$/,
+      loader: 'markdown-loader',
+      options: {
+        pedantic: true,
+        renderer
+      }
+    })
 
     return config
   }

--- a/next.config.js
+++ b/next.config.js
@@ -18,7 +18,7 @@ module.exports = {
       test: /\.md$/,
       use: [{
         loader: 'html-loader'
-      },{
+      }, {
         loader: 'markdown-loader',
         options: {
           pedantic: true,

--- a/next.config.js
+++ b/next.config.js
@@ -16,15 +16,15 @@ module.exports = {
     // Markdown loader so we can use docs as .md files
     config.module.rules.push({
       test: /\.md$/,
-      loader: 'html-loader'
-    })
-    config.module.rules.push({
-      test: /\.md$/,
-      loader: 'markdown-loader',
-      options: {
-        pedantic: true,
-        renderer
-      }
+      use: [{
+        loader: 'html-loader'
+      },{
+        loader: 'markdown-loader',
+        options: {
+          pedantic: true,
+          renderer
+        }
+      }]
     })
 
     return config

--- a/package.json
+++ b/package.json
@@ -20,9 +20,14 @@
   "dependencies": {
     "glamor": "^2.20.25",
     "glamorous": "^3.16.0",
+    "html-loader": "^0.4.5",
+    "json-loader": "^0.5.4",
+    "markdown-loader": "^2.0.0",
+    "marked": "^0.3.6",
     "next": "^2.4.0",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-markdown": "^2.5.0",
     "webpack": "^2.6.1"
   },
   "devDependencies": {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -23,8 +23,8 @@ export default class MyDocument extends Document {
         <Head>
           <title>glamorous - React component styling solved 💄</title>
           <style dangerouslySetInnerHTML={{__html: this.props.css}}/>
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <link rel="shortcut icon" type="image/x-icon" href="/static/images/icon.png" />
+          <meta name="viewport" content="width=device-width, initial-scale=1"/>
+          <link rel="shortcut icon" type="image/x-icon" href="/static/images/icon.png"/>
         </Head>
         <body>
           <Main/>

--- a/pages/docs.js
+++ b/pages/docs.js
@@ -1,26 +1,52 @@
 import React from 'react'
 import {rehydrate} from 'glamor'
 import glamorous from 'glamorous'
-import Logo from '../components/glamorous-logo'
 import Layout from '../components/layout'
+import * as colors from '../styles/colors'
+
+// Define main file here so we can require the markdown file in the client
+let main = ''
 
 // Adds server generated styles to glamor cache.
 // Has to run before any `style()` calls
 // '__NEXT_DATA__.ids' is set in '_document.js'
 if (typeof window !== 'undefined' && window.__NEXT_DATA__ !== undefined) {
+  main = require('../docs/main.md')
   rehydrate(window.__NEXT_DATA__.ids)
 }
 
-const {Div} = glamorous
+const MarkdownWrapper = glamorous.div({
+  margin: '20px auto',
+  width: '100%',
+  maxWidth: '50rem',
 
-export default () => {
-  return (
-    <Layout>
-      <Div margin="20px auto" maxWidth={700} textAlign="center">
-        <Logo marginTop={50}/>
-        <glamorous.P>edit in pages/docs.js</glamorous.P>
-      </Div>
-    </Layout>
-  )
+  '& pre, & code': {
+    backgroundColor: '#eee',
+    fontSize: '1rem'
+  },
+  '& pre': {
+    padding: '1rem',
+    overflowX: 'scroll'
+  },
+  '& a': {
+    textDecoration: 'none',
+    color: colors.primary
+  }
+})
+
+export default class Docs extends React.Component {
+  rawMarkup() {
+    return {__html: main}
+  }
+
+  render() {
+    return (
+      <Layout>
+        <MarkdownWrapper>
+          <div dangerouslySetInnerHTML={this.rawMarkup()}/>
+        </MarkdownWrapper>
+      </Layout>
+    )
+  }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -1090,6 +1094,13 @@ callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
+camel-case@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -1175,6 +1186,12 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
+clean-css@4.1.x:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.3.tgz#07cfe8980edb20d455ddc23aadcf1e04c6e509ce"
+  dependencies:
+    source-map "0.5.x"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -1229,9 +1246,33 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.9.x, commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+
+commonmark-react-renderer@^4.2.4:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/commonmark-react-renderer/-/commonmark-react-renderer-4.3.2.tgz#f30cdebd66141eef45ccd2d82fc00861e1e1f747"
+  dependencies:
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.isplainobject "^4.0.6"
+    pascalcase "^0.1.1"
+    xss-filters "^1.2.6"
+
+commonmark@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.24.0.tgz#b80de0182c546355643aa15db12bfb282368278f"
+  dependencies:
+    entities "~ 1.1.1"
+    mdurl "~ 1.0.1"
+    string.prototype.repeat "^0.2.0"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1612,6 +1653,10 @@ enhanced-resolve@^3.0.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
+"entities@~ 1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
 "errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -1695,6 +1740,13 @@ es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbo
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+es6-templates@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
+  dependencies:
+    recast "~0.11.12"
+    through "~2.3.6"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"
@@ -1876,7 +1928,7 @@ esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.1.1:
+esprima@^3.1.1, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -2002,6 +2054,10 @@ fast-levenshtein@~2.0.4:
 fast-memoize@^2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.2.7.tgz#f145c5c22039cedf0a1d4ff6ca592ad0268470ca"
+
+fastparse@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
 fb-watchman@^1.8.0:
   version "1.9.2"
@@ -2338,6 +2394,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -2408,6 +2468,10 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+he@1.1.x:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2444,6 +2508,29 @@ html-encoding-sniffer@^1.0.1:
 html-entities@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+
+html-loader@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.4.5.tgz#5fbcd87cd63a5c49a7fce2fe56f425e05729c68c"
+  dependencies:
+    es6-templates "^0.2.2"
+    fastparse "^1.1.1"
+    html-minifier "^3.0.1"
+    loader-utils "^1.0.2"
+    object-assign "^4.1.0"
+
+html-minifier@^3.0.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.2.tgz#d73bc3ff448942408818ce609bf3fb0ea7ef4eb7"
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.1.x"
+    commander "2.9.x"
+    he "1.1.x"
+    ncname "1.0.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.0.x"
 
 html-tag-names@^1.1.1:
   version "1.1.1"
@@ -2504,6 +2591,10 @@ ignore@^3.2.0, ignore@^3.2.6:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -3257,6 +3348,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
 lodash.camelcase@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -3268,6 +3363,10 @@ lodash.cond@^4.3.0:
 lodash.isequal@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
 lodash.kebabcase@^4.0.1:
   version "4.1.1"
@@ -3308,6 +3407,10 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
@@ -3335,9 +3438,24 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+markdown-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-loader/-/markdown-loader-2.0.0.tgz#421862d38c4224fd3615eb648017ea385b562d78"
+  dependencies:
+    loader-utils "^0.2.16"
+    marked "^0.3.6"
+
+marked@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
 md5-file@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.1.1.tgz#db3c92c09bbda5c2de883fa5490dd711fddbbab9"
+
+"mdurl@~ 1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -3506,6 +3624,12 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+ncname@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ncname/-/ncname-1.0.0.tgz#5b57ad18b1ca092864ef62b0b1ed8194f383b71c"
+  dependencies:
+    xml-char-classes "^1.0.0"
+
 ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
@@ -3564,6 +3688,12 @@ next@^2.4.0:
     webpack-dev-middleware "1.10.2"
     webpack-hot-middleware "2.18.0"
     write-file-webpack-plugin "4.0.2"
+
+no-case@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
+  dependencies:
+    lower-case "^1.1.1"
 
 node-fetch@^1.0.1:
   version "1.7.0"
@@ -3806,6 +3936,12 @@ pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
 
+param-case@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  dependencies:
+    no-case "^2.2.0"
+
 parse-asn1@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
@@ -3834,6 +3970,10 @@ parse-json@^2.2.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -3978,7 +4118,7 @@ pretty-format@^20.0.3:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
-private@^0.1.6:
+private@^0.1.6, private@~0.1.5:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
@@ -4004,7 +4144,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@15.5.10, prop-types@^15.5.1, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4107,6 +4247,15 @@ react-html-attributes@^1.3.0:
   dependencies:
     html-element-attributes "^1.0.0"
 
+react-markdown@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-2.5.0.tgz#b1c61904fee5895886803bd9df7db23c3dc3a89e"
+  dependencies:
+    commonmark "^0.24.0"
+    commonmark-react-renderer "^4.2.4"
+    in-publish "^2.0.0"
+    prop-types "^15.5.1"
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -4188,6 +4337,15 @@ readline2@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
 
+recast@~0.11.12:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -4262,6 +4420,10 @@ regjsparser@^0.1.4:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   dependencies:
     jsesc "~0.5.0"
+
+relateurl@0.2.x:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
 remove-trailing-separator@^1.0.1:
   version "1.0.1"
@@ -4523,7 +4685,7 @@ source-map-support@0.4.15, source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.6"
 
-source-map@0.5.6, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.6, source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -4625,6 +4787,10 @@ string-width@^2.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
+
+string.prototype.repeat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
 
 string_decoder@^0.10.25:
   version "0.10.31"
@@ -4777,7 +4943,7 @@ throat@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -4859,6 +5025,13 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
+uglify-js@3.0.x:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.11.tgz#81f594b9a24dad76e39da92f8f06e5b3bc8c2e11"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
+
 uglify-js@^2.6, uglify-js@^2.8.27, uglify-js@^2.8.5:
   version "2.8.27"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
@@ -4902,6 +5075,10 @@ update-notifier@^2.1.0:
     lazy-req "^2.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
+
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"
@@ -5172,6 +5349,10 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
+xml-char-classes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
+
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
@@ -5217,6 +5398,10 @@ xo@^0.18.2:
     slash "^1.0.0"
     update-notifier "^2.1.0"
     xo-init "^0.5.0"
+
+xss-filters@^1.2.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/xss-filters/-/xss-filters-1.2.7.tgz#59fa1de201f36f2f3470dcac5f58ccc2830b0a9a"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This is a super early WIP for getting documentation into the site via .md files. Right now I'm just shoving the README from `Installation` to the end (basically) into the docs page. This addresses #5.

I'd really like some feedback and thoughts here. Ideally I can get this into a clean enough place for us to merge and then let other people flesh more of it out.

In particular, I'm not super sure that the method I have for including the .md file is correct. I get a flash where the content is missing, but every other method I've tried has failed. I'm not an expert on webpack (or anything for that matter 😭 ).

Looking at this and the documentation in general I feel that we'll wind up wanting to "hardcode" the documentation on the homepage and not use a md file. I think we'll have way more control over the look that way, and since the homepage is probably going to be a brief intro and installation instructions I don't see why we'll need to worry about lots of updates.

Deployed this here: https://glamorous-website-poiyvykcjm.now.sh