### PR TITLE
DRY up rehydration by moving to layout

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -1,7 +1,15 @@
 import React from 'react'
+import {rehydrate} from 'glamor'
 import glamorous from 'glamorous'
 import Nav from './nav'
 import Footer from './footer'
+
+// Adds server generated styles to glamor cache.
+// Has to run before any `style()` calls
+// '__NEXT_DATA__.ids' is set in '_document.js'
+if (typeof window !== 'undefined' && window.__NEXT_DATA__ !== undefined) {
+  rehydrate(window.__NEXT_DATA__.ids)
+}
 
 export default ({children}) => {
   return (

--- a/pages/docs.js
+++ b/pages/docs.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import {rehydrate} from 'glamor'
 import glamorous from 'glamorous'
 import Layout from '../components/layout'
 import * as colors from '../styles/colors'
@@ -7,12 +6,9 @@ import * as colors from '../styles/colors'
 // Define main file here so we can require the markdown file in the client
 let main = ''
 
-// Adds server generated styles to glamor cache.
-// Has to run before any `style()` calls
-// '__NEXT_DATA__.ids' is set in '_document.js'
+// Adds in main.md on client only
 if (typeof window !== 'undefined' && window.__NEXT_DATA__ !== undefined) {
   main = require('../docs/main.md')
-  rehydrate(window.__NEXT_DATA__.ids)
 }
 
 const MarkdownWrapper = glamorous.div({

--- a/pages/examples.js
+++ b/pages/examples.js
@@ -1,15 +1,7 @@
 import React from 'react'
-import {rehydrate} from 'glamor'
 import glamorous from 'glamorous'
 import Logo from '../components/glamorous-logo'
 import Layout from '../components/layout'
-
-// Adds server generated styles to glamor cache.
-// Has to run before any `style()` calls
-// '__NEXT_DATA__.ids' is set in '_document.js'
-if (typeof window !== 'undefined' && window.__NEXT_DATA__ !== undefined) {
-  rehydrate(window.__NEXT_DATA__.ids)
-}
 
 const {Div} = glamorous
 

--- a/pages/guides.js
+++ b/pages/guides.js
@@ -1,15 +1,7 @@
 import React from 'react'
-import {rehydrate} from 'glamor'
 import glamorous from 'glamorous'
 import Logo from '../components/glamorous-logo'
 import Layout from '../components/layout'
-
-// Adds server generated styles to glamor cache.
-// Has to run before any `style()` calls
-// '__NEXT_DATA__.ids' is set in '_document.js'
-if (typeof window !== 'undefined' && window.__NEXT_DATA__ !== undefined) {
-  rehydrate(window.__NEXT_DATA__.ids)
-}
 
 const {Div} = glamorous
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,8 @@
 import React from 'react'
-import {rehydrate} from 'glamor'
 import glamorous from 'glamorous'
 import Logo from '../components/glamorous-logo'
 import {Button, SecondaryButton} from '../components/styled-links'
 import Layout from '../components/layout'
-
-// Adds server generated styles to glamor cache.
-// Has to run before any `style()` calls
-// '__NEXT_DATA__.ids' is set in '_document.js'
-if (typeof window !== 'undefined' && window.__NEXT_DATA__ !== undefined) {
-  rehydrate(window.__NEXT_DATA__.ids)
-}
 
 const {Div} = glamorous
 


### PR DESCRIPTION
We were repeating the same `rehydrate` method on every page, which is annoying. This PR moves the rehydration to `layout.js`.