### PR TITLE
fix(links): Add href to StyledAnchors inside Link components

### DIFF
--- a/__tests__/__snapshots__/api.js.snap
+++ b/__tests__/__snapshots__/api.js.snap
@@ -172,6 +172,7 @@ exports[`Testing Api Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/"
             onClick={[Function]}
           >
             <svg
@@ -222,6 +223,7 @@ exports[`Testing Api Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/basics"
             onClick={[Function]}
           >
             Basics
@@ -232,6 +234,7 @@ exports[`Testing Api Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/advanced"
             onClick={[Function]}
           >
             Advanced
@@ -242,6 +245,7 @@ exports[`Testing Api Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/examples"
             onClick={[Function]}
           >
             Examples
@@ -252,6 +256,7 @@ exports[`Testing Api Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/integrations"
             onClick={[Function]}
           >
             Integrations
@@ -262,6 +267,7 @@ exports[`Testing Api Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/api"
             onClick={[Function]}
           >
             API

--- a/__tests__/__snapshots__/basics.js.snap
+++ b/__tests__/__snapshots__/basics.js.snap
@@ -172,6 +172,7 @@ exports[`Testing Basics Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/"
             onClick={[Function]}
           >
             <svg
@@ -222,6 +223,7 @@ exports[`Testing Basics Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/basics"
             onClick={[Function]}
           >
             Basics
@@ -232,6 +234,7 @@ exports[`Testing Basics Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/advanced"
             onClick={[Function]}
           >
             Advanced
@@ -242,6 +245,7 @@ exports[`Testing Basics Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/examples"
             onClick={[Function]}
           >
             Examples
@@ -252,6 +256,7 @@ exports[`Testing Basics Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/integrations"
             onClick={[Function]}
           >
             Integrations
@@ -262,6 +267,7 @@ exports[`Testing Basics Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/api"
             onClick={[Function]}
           >
             API

--- a/__tests__/__snapshots__/examples.js.snap
+++ b/__tests__/__snapshots__/examples.js.snap
@@ -172,6 +172,7 @@ exports[`Testing Examples Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/"
             onClick={[Function]}
           >
             <svg
@@ -222,6 +223,7 @@ exports[`Testing Examples Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/basics"
             onClick={[Function]}
           >
             Basics
@@ -232,6 +234,7 @@ exports[`Testing Examples Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/advanced"
             onClick={[Function]}
           >
             Advanced
@@ -242,6 +245,7 @@ exports[`Testing Examples Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/examples"
             onClick={[Function]}
           >
             Examples
@@ -252,6 +256,7 @@ exports[`Testing Examples Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/integrations"
             onClick={[Function]}
           >
             Integrations
@@ -262,6 +267,7 @@ exports[`Testing Examples Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/api"
             onClick={[Function]}
           >
             API

--- a/__tests__/__snapshots__/integrations.js.snap
+++ b/__tests__/__snapshots__/integrations.js.snap
@@ -172,6 +172,7 @@ exports[`Testing Integrations Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/"
             onClick={[Function]}
           >
             <svg
@@ -222,6 +223,7 @@ exports[`Testing Integrations Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/basics"
             onClick={[Function]}
           >
             Basics
@@ -232,6 +234,7 @@ exports[`Testing Integrations Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/advanced"
             onClick={[Function]}
           >
             Advanced
@@ -242,6 +245,7 @@ exports[`Testing Integrations Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/examples"
             onClick={[Function]}
           >
             Examples
@@ -252,6 +256,7 @@ exports[`Testing Integrations Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/integrations"
             onClick={[Function]}
           >
             Integrations
@@ -262,6 +267,7 @@ exports[`Testing Integrations Renders! 1`] = `
         >
           <a
             className="css-1xw95l9"
+            href="/api"
             onClick={[Function]}
           >
             API

--- a/components/styled-links.js
+++ b/components/styled-links.js
@@ -34,7 +34,11 @@ const Anchor = ({href, prefetch, external, pathname, ...rest}) => {
   }
   return (
     <Link prefetch={prefetch} href={href}>
-      <StyledAnchor active={getPathname(pathname) === href} {...rest} />
+      <StyledAnchor
+        href={href}
+        active={getPathname(pathname) === href}
+        {...rest}
+      />
     </Link>
   )
 }


### PR DESCRIPTION
Fixes accessibility issues where you can't tab to nav links

Closes #39

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds `href` to the anchor tags inside the nav

<!-- Why are these changes necessary? -->
**Why**: Addresses a11y issue where you can't use the keyboard to navigate to links.

<!-- How were these changes implemented? -->
**How**: Code.


<!-- feel free to add additional comments -->
