### PR TITLE
docs($browser): add dynamic styles info to docs (basics section)

### DIFF
--- a/pages/basics/content/dynamic-styles.js
+++ b/pages/basics/content/dynamic-styles.js
@@ -1,6 +1,87 @@
 module.exports = {
-  title: 'Dynamic Styles',
+  title: 'Dynamic Styles + Static Styles',
   subtitle: '',
-  description: ``.replace(/~/g, '`'),
+  description: `
+  One of the nice bits of glamorous is that it allows you to make a clear
+  separation between your dynamic and static styles by forcing you to choose
+  between an object literal and a function. Here's an example of having both
+  dynamic and static styles:
+
+  ~~~js
+  const MyLink = glamorous.a(
+    {
+      color: 'blue',
+      textDecoration: 'none',
+    },
+    ({size = 'small'}) => ({
+      fontSize: size === 'big' ? 24 : 16,
+    }),
+    // you can continue to provide any number of arguments
+    // and ~glamor~ will merge them. In the event of a
+    // style conflict, the last one wins.
+  )
+  ~~~
+
+  You can see a live preview of this example on [codesandbox](https://codesandbox.io/s/mZkpo0lKA).
+
+  <details>
+  <summary>Note, you can also use arrays of styles if you need:</summary>
+
+  ~~~js
+  const MyDiv = glamorous.div(
+    [
+      {
+        [phoneMediaQuery]: {
+          lineHeight: 1.2,
+        },
+      },
+      {
+        [phoneMediaQuery]: {
+          lineHeight: 1.3, // this will win because it comes later
+        },
+      },
+    ],
+    ({big, square}) => {
+      const bigStyles = big ?
+      {
+        [phoneMediaQuery]: {
+          fontSize: 20,
+        },
+      } :
+        {}
+
+      const squareStyles = square ?
+      {
+        [phoneMediaQuery]: {
+          borderRadius: 0,
+        },
+      } :
+      {
+        [phoneMediaQuery]: {
+          borderRadius: '50%',
+        },
+      }
+      // note that I'm returning an array here
+      return [bigStyles, squareStyles]
+    },
+  )
+
+  // result of <MyDiv big={true} square={false} /> will be:
+  // @media (max-width: 640px) {
+  //   .css-1bzhvkr,
+  //   [data-css-1bzhvkr] {
+  //     line-height: 1.3;
+  //     font-size: 20px;
+  //     border-radius: 50%;
+  //   }
+  // }
+  //
+  // <div
+  //   class="css-1bzhvkr"
+  // />
+  ~~~
+
+  </details>
+  `.replace(/~/g, '`'),
   filename: __filename,
 }


### PR DESCRIPTION
Transferred the dynamic styles + static styles section from the glamorous github README to the
glamorous website.

#83 

**What**: Transferred over the existing glamorous documentation for the "Dynamic Styles + Static Styles" section to the glamorous website section, under "basics". 

**Why**: Updating glamorous-website with existing glamorous documentation.

**How**:  Updated file pages/basics/content/dynamic-styles.js.

<!-- feel free to add additional comments -->

I named the section on the glamour website "Dynamic Styles + Static Styles," as it is on the Github documentation, instead of just "Dynamic Styles," which is how it was listed when I started this task. 

I also changed the presentation of the external link to sandcodebox, embedding it, so:

`You can see a live preview of this example here: https://codesandbox.io/s/mZkpo0lKA`

is now:

`You can see a live preview of this example on [codesandbox](https://codesandbox.io/s/mZkpo0lKA).`

Also, the font within code blocks looks a little off locally: you can see that curly braces and parentheses are cut off.  Not sure if this is an issue, and if it is if it's fixable on my side. Let me know how I can help if I can, though!

<img width="918" alt="glamorous-screenshot" src="https://user-images.githubusercontent.com/13544620/27008650-2ac67676-4e2c-11e7-96f3-a1f301e18afb.png">

Here is a highlighted example showing line-height differences:

<img width="564" alt="glamorous-screenshot-2" src="https://user-images.githubusercontent.com/13544620/27008671-eecbbc34-4e2c-11e7-8860-55912db801c8.png">