### PR TITLE
docs($browser): add installation info to docs

### DIFF
--- a/pages/basics/content/install.js
+++ b/pages/basics/content/install.js
@@ -2,77 +2,63 @@ module.exports = {
   title: 'Installation',
   subtitle: 'Something',
   description: `
-  This module is distributed via [npm](https://www.npmjs.com/) which is bundled with [node](https://nodejs.org) and should be installed as one of your project's ~dependencies~:
+    This module is distributed via [npm](https://www.npmjs.com/) which is bundled with [node](https://nodejs.org) and should be installed as one of your project's ~dependencies~:
 
-  ~~~js
-  npm install --save glamorous
-  ~~~
+    ~~~js
+    npm install --save glamorous
+    ~~~
 
-  This also depends on ~react~ and ~glamor~ so you'll need those in your project as well (if you don't already have them):
+    This also depends on ~react~ and ~glamor~ so you'll need those in your project as well (if you don't already have them):
 
-  ~~~js
-  npm install --save react glamor
-  ~~~
+    ~~~js
+    npm install --save react glamor
+    ~~~
 
-  > NOTE: If you're using React v15.5 or greater, you'll also need to have
-  > ~prop-types~ installed: ~npm install --save prop-types~
+    > NOTE: If you're using React v15.5 or greater, you'll also need to have
+    > ~prop-types~ installed: ~npm install --save prop-types~
 
-  You can then use one of the module formats:
+    You can then use one of the module formats:
 
-  - ~main~: ~dist/glamorous.cjs.js~ - exports itself as a CommonJS module
-  - ~global~: ~dist/glamorous.umd.js~ and ~dist/glamorous.umd.min.js~ - exports itself as a umd module which is consumable in several environments, the most notable as a global.
-  - ~jsnext:main~ and module: ~dist/glamorous.es.js~ - exports itself using the ES modules specification, you'll need to configure webpack to make use of this file do this using the resolve.mainFields property.
+    - ~main~: ~dist/glamorous.cjs.js~ - exports itself as a CommonJS module
+    - ~global~: ~dist/glamorous.umd.js~ and ~dist/glamorous.umd.min.js~ - exports itself as a umd module which is consumable in several environments, the most notable as a global.
+    - ~jsnext:main~ and module: ~dist/glamorous.es.js~ - exports itself using the ES modules specification, you'll need to configure webpack to make use of this file do this using the resolve.mainFields property.
 
-  The most common use-case is consuming this module via CommonJS:
+    The most common use-case is consuming this module via CommonJS:
 
-  ~~~js
-  const glamorous = require('glamorous')
-  const {ThemeProvider} = glamorous
-  // etc.
-  ~~~
+    ~~~js
+    const glamorous = require('glamorous')
+    const {ThemeProvider} = glamorous
+    // etc.
+    ~~~
 
-  If you're transpiling (and/or using the jsnext:main):
+    If you're transpiling (and/or using the jsnext:main):
 
-  ~~~js
-  import glamorous, {ThemeProvider} from 'glamorous'
+    ~~~js
+    import glamorous, {ThemeProvider} from 'glamorous'
 
-  // you can also import specific Glamorous Components (see section below on "Built-in" components)
-  import {Div, H2} from 'glamorous'
+    // you can also import specific Glamorous Components (see section below on "Built-in" components)
+    import {Div, H2} from 'glamorous'
 
-  // tags with the same name as built-in JavaScript objects are importable with a Tag suffix
-  // and tag names that contain dashes are transformed to CamelCase
-  import {MapTag, ColorProfile} from 'glamorous'
-  ~~~
+    // tags with the same name as built-in JavaScript objects are importable with a Tag suffix
+    // and tag names that contain dashes are transformed to CamelCase
+    import {MapTag, ColorProfile} from 'glamorous'
+    ~~~
 
-  If you want to use the global:
+    If you want to use the global:
 
-  ~~~js
-  <!-- Load dependencies -->
-  <script src="https://unpkg.com/react/dist/react.js"></script>
-  <script src="https://unpkg.com/prop-types/prop-types.js"></script>
-  <script src="https://unpkg.com/glamor/umd/index.js"></script>
-  <!-- load library -->
-  <script src="https://unpkg.com/glamorous/dist/glamorous.umd.js"></script>
-  <script>
-  // Use window.glamorous here...
-  const glamorous = window.glamorous
-  const {ThemeProvider} = glamorous
-  </script>
-  ~~~
-
-  #### React Native
-
-  Glamorous offers a version for React Native projects called ~glamorous-native~.
-
-  ~~~js
-  npm install glamorous-native --save
-  ~~~
-
-  You can learn more at the [glamorous-native project](https://github.com/robinpowered/glamorous-native).
-
-  #### Typescript
-
-  Glamorous includes typescript definition files. For usage notes and known issues see [typescript usage](https://github.com/paypal/glamorous/blob/master/other/TYPESCRIPT_USAGE.md).
+    ~~~js
+    <!-- Load dependencies -->
+    <script src="https://unpkg.com/react/dist/react.js"></script>
+    <script src="https://unpkg.com/prop-types/prop-types.js"></script>
+    <script src="https://unpkg.com/glamor/umd/index.js"></script>
+    <!-- load library -->
+    <script src="https://unpkg.com/glamorous/dist/glamorous.umd.js"></script>
+    <script>
+    // Use window.glamorous here...
+    const glamorous = window.glamorous
+    const {ThemeProvider} = glamorous
+    </script>
+    ~~~
   `.replace(/~/g, '`'),
   filename: __filename,
 }

--- a/pages/basics/content/install.js
+++ b/pages/basics/content/install.js
@@ -16,6 +16,63 @@ module.exports = {
 
   > NOTE: If you're using React v15.5 or greater, you'll also need to have
   > ~prop-types~ installed: ~npm install --save prop-types~
+
+  You can then use one of the module formats:
+
+  - ~main~: ~dist/glamorous.cjs.js~ - exports itself as a CommonJS module
+  - ~global~: ~dist/glamorous.umd.js~ and ~dist/glamorous.umd.min.js~ - exports itself as a umd module which is consumable in several environments, the most notable as a global.
+  - ~jsnext:main~ and module: ~dist/glamorous.es.js~ - exports itself using the ES modules specification, you'll need to configure webpack to make use of this file do this using the resolve.mainFields property.
+
+  The most common use-case is consuming this module via CommonJS:
+
+  ~~~js
+  const glamorous = require('glamorous')
+  const {ThemeProvider} = glamorous
+  // etc.
+  ~~~
+
+  If you're transpiling (and/or using the jsnext:main):
+
+  ~~~js
+  import glamorous, {ThemeProvider} from 'glamorous'
+
+  // you can also import specific Glamorous Components (see section below on "Built-in" components)
+  import {Div, H2} from 'glamorous'
+
+  // tags with the same name as built-in JavaScript objects are importable with a Tag suffix
+  // and tag names that contain dashes are transformed to CamelCase
+  import {MapTag, ColorProfile} from 'glamorous'
+  ~~~
+
+  If you want to use the global:
+
+  ~~~js
+  <!-- Load dependencies -->
+  <script src="https://unpkg.com/react/dist/react.js"></script>
+  <script src="https://unpkg.com/prop-types/prop-types.js"></script>
+  <script src="https://unpkg.com/glamor/umd/index.js"></script>
+  <!-- load library -->
+  <script src="https://unpkg.com/glamorous/dist/glamorous.umd.js"></script>
+  <script>
+  // Use window.glamorous here...
+  const glamorous = window.glamorous
+  const {ThemeProvider} = glamorous
+  </script>
+  ~~~
+
+  #### React Native
+
+  Glamorous offers a version for React Native projects called ~glamorous-native~.
+
+  ~~~js
+  npm install glamorous-native --save
+  ~~~
+
+  You can learn more at the [glamorous-native project](https://github.com/robinpowered/glamorous-native).
+
+  #### Typescript
+
+  Glamorous includes typescript definition files. For usage notes and known issues see [typescript usage](https://github.com/paypal/glamorous/blob/master/other/TYPESCRIPT_USAGE.md).
   `.replace(/~/g, '`'),
   filename: __filename,
 }


### PR DESCRIPTION
Move install instructions from glamorous README to glamorous website under basics section.

#81 

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Add installation instructions from glamorous README to glamorous website basics section

<!-- Why are these changes necessary? -->
**Why**: Update website with installation information

<!-- How were these changes implemented? -->
**How**: Changed `pages/basics/content/install.js`.


<!-- feel free to add additional comments -->
Used `h4` for subsection headings. The font within code blocks looks off for some reason, the line height doesn't seem quite right. Also it would be great to add base styles to `ul` and `ol` to make them look good.

![screen shot 2017-06-10 at 11 41 29 pm](https://user-images.githubusercontent.com/297132/27008969-63034762-4e36-11e7-99f6-1b035896713d.png)
