### PR TITLE
add is-fork check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
   - npm install -g now
 script:
   - npm start validateAndDeploy
-  # report code coverage
 after_success:
+  # report code coverage
   - npm install codecov
   - codecov
 branches:

--- a/other/now-travis
+++ b/other/now-travis
@@ -101,7 +101,9 @@ const {TRAVIS_EVENT_TYPE, TRAVIS_PULL_REQUEST_SHA, TRAVIS_COMMIT} = process.env
 
 switch (TRAVIS_EVENT_TYPE) {
   case 'pull_request': {
-    deploy('staging', TRAVIS_PULL_REQUEST_SHA)
+    if (!isFork()) {
+      deploy('staging', TRAVIS_PULL_REQUEST_SHA)
+    }
     break
   }
   case 'push': {
@@ -111,6 +113,13 @@ switch (TRAVIS_EVENT_TYPE) {
   default: {
     console.log(`${TRAVIS_EVENT_TYPE} is not supported by now-travis`)
   }
+}
+
+function isFork() {
+  const {TRAVIS_PULL_REQUEST_SLUG, TRAVIS_REPO_SLUG} = process.env
+  const [prOwner] = TRAVIS_PULL_REQUEST_SLUG.split('/')
+  const [owner] = TRAVIS_REPO_SLUG.split('/')
+  return owner !== prOwner
 }
 
 function getUrl(content) {

--- a/other/now-travis
+++ b/other/now-travis
@@ -24,6 +24,13 @@ const client = github.client(githubToken)
 const ghRepo = client.repo(process.env.TRAVIS_REPO_SLUG)
 
 function deploy(context, sha) {
+  if (isFork()) {
+    updateStatus({
+      state: 'success',
+      description: `▲ Now ${context} deployment is skipped for forks...`,
+    })
+    return
+  }
   let stdout = ''
   updateStatus({
     state: 'pending',
@@ -101,9 +108,7 @@ const {TRAVIS_EVENT_TYPE, TRAVIS_PULL_REQUEST_SHA, TRAVIS_COMMIT} = process.env
 
 switch (TRAVIS_EVENT_TYPE) {
   case 'pull_request': {
-    if (!isFork()) {
-      deploy('staging', TRAVIS_PULL_REQUEST_SHA)
-    }
+    deploy('staging', TRAVIS_PULL_REQUEST_SHA)
     break
   }
   case 'push': {
@@ -117,6 +122,9 @@ switch (TRAVIS_EVENT_TYPE) {
 
 function isFork() {
   const {TRAVIS_PULL_REQUEST_SLUG, TRAVIS_REPO_SLUG} = process.env
+  if (!TRAVIS_PULL_REQUEST_SLUG) {
+    return false
+  }
   const [prOwner] = TRAVIS_PULL_REQUEST_SLUG.split('/')
   const [owner] = TRAVIS_REPO_SLUG.split('/')
   return owner !== prOwner

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -39,17 +39,21 @@ module.exports = {
     validate: {
       description:
         'This runs several scripts to make sure things look good before committing or on clean install',
-      script: concurrent.nps('lint', 'test', 'build'),
+      script: concurrent.nps('lint', 'test'),
     },
     deploy: {
       hiddenFromHelp,
       description: 'Runs the deploy script.',
       script: series('nps build.info', './other/now-travis'),
     },
+    validateAndBuild: {
+      hiddenFromHelp,
+      script: concurrent.nps('validate', 'build'),
+    },
     validateAndDeploy: {
       hiddenFromHelp,
       description: 'This runs the validation and deploy concurrently',
-      script: concurrent.nps('validate', 'deploy'),
+      script: concurrent.nps('validateAndBuild', 'deploy'),
     },
   },
   options: {silent: false},


### PR DESCRIPTION

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This adds an `isFork` check in `now-travis`

<!-- Why are these changes necessary? -->
**Why**: So the people making PRs from forks don't get a failed travis build

<!-- How were these changes implemented? -->
**How**: updating `now-travis` to reference some environment variables.


<!-- feel free to add additional comments -->
