### PR TITLE
Syntax highlighting

### DIFF
--- a/components/__tests__/__snapshots__/interactive-markdown.js.snap
+++ b/components/__tests__/__snapshots__/interactive-markdown.js.snap
@@ -16,18 +16,23 @@ exports[`parses HTML pragmas into syntax highlighted static code blocks 1`] = `
     component={[Function]}
     language="html"
   >
-    <pre
-      className="language-html"
+    <CodeBlock
+      code="render(&lt;button onClick={() => alert('Hello World')}>Hello World<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>button</span><span class=\\"token punctuation\\">></span></span>)"
+      language="html"
     >
-      <code
+      <pre
         className="language-html"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "render(&lt;button onClick={() => alert('Hello World')}>Hello World<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>button</span><span class=\\"token punctuation\\">></span></span>)",
+      >
+        <code
+          className="language-html"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "render(&lt;button onClick={() => alert('Hello World')}>Hello World<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>button</span><span class=\\"token punctuation\\">></span></span>)",
+            }
           }
-        }
-      />
-    </pre>
+        />
+      </pre>
+    </CodeBlock>
   </StaticCodeBlock>
   <div
     dangerouslySetInnerHTML={
@@ -58,18 +63,23 @@ exports[`parses JavaScript pragmas into syntax highlighted static code blocks 1`
     component={[Function]}
     language="javascript"
   >
-    <pre
-      className="language-javascript"
+    <CodeBlock
+      code="<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>"
+      language="javascript"
     >
-      <code
+      <pre
         className="language-javascript"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+      >
+        <code
+          className="language-javascript"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+            }
           }
-        }
-      />
-    </pre>
+        />
+      </pre>
+    </CodeBlock>
   </StaticCodeBlock>
   <div
     dangerouslySetInnerHTML={
@@ -100,18 +110,23 @@ exports[`parses JavaScript pragmas into syntax highlighted static code blocks 2`
     component={[Function]}
     language="javascript"
   >
-    <pre
-      className="language-javascript"
+    <CodeBlock
+      code="<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>"
+      language="javascript"
     >
-      <code
+      <pre
         className="language-javascript"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+      >
+        <code
+          className="language-javascript"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+            }
           }
-        }
-      />
-    </pre>
+        />
+      </pre>
+    </CodeBlock>
   </StaticCodeBlock>
   <div
     dangerouslySetInnerHTML={
@@ -244,18 +259,23 @@ exports[`parses shell pragmas into syntax highlighted static code blocks 1`] = `
     component={[Function]}
     language="bash"
   >
-    <pre
-      className="language-bash"
+    <CodeBlock
+      code="render<span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> alert<span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span>/button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>"
+      language="bash"
     >
-      <code
+      <pre
         className="language-bash"
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "render<span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> alert<span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span>/button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+      >
+        <code
+          className="language-bash"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "render<span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> alert<span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span>/button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+            }
           }
-        }
-      />
-    </pre>
+        />
+      </pre>
+    </CodeBlock>
   </StaticCodeBlock>
   <div
     dangerouslySetInnerHTML={

--- a/components/__tests__/__snapshots__/interactive-markdown.js.snap
+++ b/components/__tests__/__snapshots__/interactive-markdown.js.snap
@@ -7,8 +7,32 @@ exports[`parses HTML pragmas into syntax highlighted static code blocks 1`] = `
       Object {
         "__html": "<h1>hello world</h1>
       <p>I am some content</p>
-      <pre><code class=\\"language-sh\\">render(&#x3C;button onClick={() => alert('Hello World')}>Hello World&#x3C;/button>)
-      </code></pre>
+      ",
+      }
+    }
+  />
+  <StaticCodeBlock
+    code="render(&lt;button onClick={() => alert('Hello World')}>Hello World<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>button</span><span class=\\"token punctuation\\">></span></span>)"
+    component={[Function]}
+    language="html"
+  >
+    <pre
+      className="language-html"
+    >
+      <code
+        className="language-html"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "render(&lt;button onClick={() => alert('Hello World')}>Hello World<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;/</span>button</span><span class=\\"token punctuation\\">></span></span>)",
+          }
+        }
+      />
+    </pre>
+  </StaticCodeBlock>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
       <p>I am some more content
       </p>
       ",
@@ -19,6 +43,48 @@ exports[`parses HTML pragmas into syntax highlighted static code blocks 1`] = `
 `;
 
 exports[`parses JavaScript pragmas into syntax highlighted static code blocks 1`] = `
+<div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<h1>hello world</h1>
+      <p>I am some content</p>
+      ",
+      }
+    }
+  />
+  <StaticCodeBlock
+    code="<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>"
+    component={[Function]}
+    language="javascript"
+  >
+    <pre
+      className="language-javascript"
+    >
+      <code
+        className="language-javascript"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+          }
+        }
+      />
+    </pre>
+  </StaticCodeBlock>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+      <p>I am some more content
+      </p>
+      ",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`parses JavaScript pragmas into syntax highlighted static code blocks 2`] = `
 <div>
   <div
     dangerouslySetInnerHTML={
@@ -169,8 +235,32 @@ exports[`parses shell pragmas into syntax highlighted static code blocks 1`] = `
       Object {
         "__html": "<h1>hello world</h1>
       <p>I am some content</p>
-      <pre><code class=\\"language-sh\\">render(&#x3C;button onClick={() => alert('Hello World')}>Hello World&#x3C;/button>)
-      </code></pre>
+      ",
+      }
+    }
+  />
+  <StaticCodeBlock
+    code="render<span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> alert<span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span>/button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>"
+    component={[Function]}
+    language="bash"
+  >
+    <pre
+      className="language-bash"
+    >
+      <code
+        className="language-bash"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "render<span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> alert<span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span>/button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+          }
+        }
+      />
+    </pre>
+  </StaticCodeBlock>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
       <p>I am some more content
       </p>
       ",

--- a/components/__tests__/__snapshots__/interactive-markdown.js.snap
+++ b/components/__tests__/__snapshots__/interactive-markdown.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parses HTML pragmas into syntax highlighted static code blocks 1`] = `
+<div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<h1>hello world</h1>
+      <p>I am some content</p>
+      <pre><code class=\\"language-sh\\">render(&#x3C;button onClick={() => alert('Hello World')}>Hello World&#x3C;/button>)
+      </code></pre>
+      <p>I am some more content
+      </p>
+      ",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`parses JavaScript pragmas into syntax highlighted static code blocks 1`] = `
+<div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<h1>hello world</h1>
+      <p>I am some content</p>
+      ",
+      }
+    }
+  />
+  <StaticCodeBlock
+    code="<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>"
+    component={[Function]}
+    language="javascript"
+  >
+    <pre
+      className="language-javascript"
+    >
+      <code
+        className="language-javascript"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<span class=\\"token function\\">render</span><span class=\\"token punctuation\\">(</span><span class=\\"token operator\\">&lt;</span>button onClick<span class=\\"token operator\\">=</span><span class=\\"token punctuation\\">{</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span> <span class=\\"token operator\\">=</span><span class=\\"token operator\\">></span> <span class=\\"token function\\">alert</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'Hello World'</span><span class=\\"token punctuation\\">)</span><span class=\\"token punctuation\\">}</span><span class=\\"token operator\\">></span>Hello World<span class=\\"token operator\\">&lt;</span><span class=\\"token operator\\">/</span>button<span class=\\"token operator\\">></span><span class=\\"token punctuation\\">)</span>",
+          }
+        }
+      />
+    </pre>
+  </StaticCodeBlock>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+      <p>I am some more content
+      </p>
+      ",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`parses interactive pragmas into CodePreviews 1`] = `
 <div>
   <div
@@ -93,6 +153,24 @@ exports[`parses interactive pragmas into CodePreviews 2`] = `
     dangerouslySetInnerHTML={
       Object {
         "__html": "
+      <p>I am some more content
+      </p>
+      ",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`parses shell pragmas into syntax highlighted static code blocks 1`] = `
+<div>
+  <div
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<h1>hello world</h1>
+      <p>I am some content</p>
+      <pre><code class=\\"language-sh\\">render(&#x3C;button onClick={() => alert('Hello World')}>Hello World&#x3C;/button>)
+      </code></pre>
       <p>I am some more content
       </p>
       ",

--- a/components/__tests__/__snapshots__/static-code-block.js.snap
+++ b/components/__tests__/__snapshots__/static-code-block.js.snap
@@ -2,17 +2,22 @@
 
 exports[`renders HTML code block string with the pragma language classname 1`] = `
 <div>
-  <pre
-    className="language-javascript"
+  <CodeBlock
+    code="<span>// some code</span>"
+    language="javascript"
   >
-    <code
+    <pre
       className="language-javascript"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<span>// some code</span>",
+    >
+      <code
+        className="language-javascript"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<span>// some code</span>",
+          }
         }
-      }
-    />
-  </pre>
+      />
+    </pre>
+  </CodeBlock>
 </div>
 `;

--- a/components/__tests__/__snapshots__/static-code-block.js.snap
+++ b/components/__tests__/__snapshots__/static-code-block.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders HTML code block string with the pragma language classname 1`] = `
+<div>
+  <pre
+    className="language-javascript"
+  >
+    <code
+      className="language-javascript"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<span>// some code</span>",
+        }
+      }
+    />
+  </pre>
+</div>
+`;

--- a/components/__tests__/interactive-markdown.js
+++ b/components/__tests__/interactive-markdown.js
@@ -26,21 +26,26 @@ test('parses interactive pragmas into CodePreviews', async () => {
 })
 
 test('parses JavaScript pragmas into syntax highlighted static code blocks', () => {
-  const markdown = getMarkdownWithPragma('js')
+  const markdown = getMarkdownWithPragma('javascript')
   const elements = interactiveMarkdown(markdown)
   const wrapper = mount(<div>{elements}</div>)
   expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
+
+  const markdownShortName = getMarkdownWithPragma('js')
+  const elementsShortName = interactiveMarkdown(markdownShortName)
+  const wrapperShortName = mount(<div>{elementsShortName}</div>)
+  expect(toJson(wrapperShortName)).toMatchSnapshotWithGlamor()
 })
 
 test('parses shell pragmas into syntax highlighted static code blocks', () => {
-  const markdown = getMarkdownWithPragma('sh')
+  const markdown = getMarkdownWithPragma('bash')
   const elements = interactiveMarkdown(markdown)
   const wrapper = mount(<div>{elements}</div>)
   expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
 })
 
 test('parses HTML pragmas into syntax highlighted static code blocks', () => {
-  const markdown = getMarkdownWithPragma('sh')
+  const markdown = getMarkdownWithPragma('html')
   const elements = interactiveMarkdown(markdown)
   const wrapper = mount(<div>{elements}</div>)
   expect(toJson(wrapper)).toMatchSnapshotWithGlamor()

--- a/components/__tests__/interactive-markdown.js
+++ b/components/__tests__/interactive-markdown.js
@@ -12,16 +12,10 @@ function flushAllPromises() {
 }
 
 test('parses interactive pragmas into CodePreviews', async () => {
-  const markdown = `
-    # hello world
-
-    I am some content
-    ~~~interactive {clickToRender: true, summary: 'I am the summary'}
-    render(<button onClick={() => alert('Hello World')}>Hello World</button>)
-    ~~~
-
-    I am some more content
-  `
+  const markdown = getMarkdownWithPragma('interactive', {
+    clickToRender: true,
+    summary: 'I am the summary',
+  })
   const elements = interactiveMarkdown(markdown)
   const wrapper = mount(<div>{elements}</div>)
   expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
@@ -30,3 +24,37 @@ test('parses interactive pragmas into CodePreviews', async () => {
   await flushAllPromises()
   expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
 })
+
+test('parses JavaScript pragmas into syntax highlighted static code blocks', () => {
+  const markdown = getMarkdownWithPragma('js')
+  const elements = interactiveMarkdown(markdown)
+  const wrapper = mount(<div>{elements}</div>)
+  expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
+})
+
+test('parses shell pragmas into syntax highlighted static code blocks', () => {
+  const markdown = getMarkdownWithPragma('sh')
+  const elements = interactiveMarkdown(markdown)
+  const wrapper = mount(<div>{elements}</div>)
+  expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
+})
+
+test('parses HTML pragmas into syntax highlighted static code blocks', () => {
+  const markdown = getMarkdownWithPragma('sh')
+  const elements = interactiveMarkdown(markdown)
+  const wrapper = mount(<div>{elements}</div>)
+  expect(toJson(wrapper)).toMatchSnapshotWithGlamor()
+})
+
+function getMarkdownWithPragma(pragma, options) {
+  return `
+    # hello world
+
+    I am some content
+    ~~~${pragma} ${JSON.stringify(options)}
+    render(<button onClick={() => alert('Hello World')}>Hello World</button>)
+    ~~~
+
+    I am some more content
+  `
+}

--- a/components/__tests__/static-code-block.js
+++ b/components/__tests__/static-code-block.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import {mount} from 'enzyme'
+import toJson from 'enzyme-to-json'
+import staticCodeBlock from '../static-code-block'
+
+test('renders HTML code block string with the pragma language classname', () => {
+  const elements = staticCodeBlock({
+    code: '<span>// some code</span>',
+    language: 'javascript',
+  })
+  const wrapper = mount(<div>{elements}</div>)
+  expect(toJson(wrapper)).toMatchSnapshot()
+})

--- a/components/interactive-markdown.js
+++ b/components/interactive-markdown.js
@@ -5,12 +5,13 @@ import React from 'react'
 import remark from 'remark'
 import remarkHtml from 'remark-html'
 import visit from 'unist-util-visit'
-import StaticCodeBlock from './static-code-block'
 import CodePreview from './code-preview'
 import Callout from './callout'
 import ClickToRender from './click-to-render'
 import highlighter from './utils/highlighter'
+import StaticCodeBlock from './static-code-block'
 import stripIndent from './utils/strip-indent'
+import {or} from './utils/specifications'
 
 export default interactiveMarkdown
 
@@ -28,72 +29,101 @@ function ClickToRenderCodePreview(props) {
   )
 }
 
+function highlightWithPrism(code, language) {
+  return Prism.highlight(code, Prism.languages[language])
+}
+
+function createSupportedPragmaMatcher() {
+  const prismHighlighter = highlighter(highlightWithPrism)
+  const highlightHtml = prismHighlighter('html')
+  const highlightJavaScript = prismHighlighter('javascript')
+  const highlightBash = prismHighlighter('bash')
+
+  const codeBlockHandler = createCodeHandler(StaticCodeBlock)
+  const htmlHandler = highlightHtml(codeBlockHandler)
+  const javaScriptHandler = highlightJavaScript(codeBlockHandler)
+  const bashHandler = highlightBash(codeBlockHandler)
+  const codePreviewHandler = createCodeHandler(CodePreview)
+  const clickToRenderCodePreviewHandler = createCodeHandler(
+    ClickToRenderCodePreview,
+  )
+
+  const pragmaHandlers = {
+    interactive(options, value) {
+      const interativeCodeBlock = options.clickToRender ?
+        clickToRenderCodePreviewHandler :
+        codePreviewHandler
+      return interativeCodeBlock(options, value)
+    },
+    callout(options, value) {
+      return {component: Callout, children: value, ...options}
+    },
+    javascript(options, value) {
+      return javaScriptHandler(options, value)
+    },
+    bash(options, value) {
+      return bashHandler(options, value)
+    },
+    html(options, value) {
+      return htmlHandler(options, value)
+    },
+  }
+
+  return function matcher(specification) {
+    const supportedPragma = Object.keys(pragmaHandlers).find(specification)
+    return pragmaHandlers[supportedPragma] ?
+      pragmaHandlers[supportedPragma] :
+      codePreviewHandler
+  }
+}
+
+function matchPragmaByLanguageName(lang) {
+  return function specification(pragma) {
+    return lang === pragma
+  }
+}
+
+function matchPragmaByLanguageShortName(lang) {
+  const names = {
+    javascript: 'js',
+  }
+
+  return function specification(pragma) {
+    return lang === names[pragma]
+  }
+}
+
 function createCodeHandler(component) {
   return function codeHandler(options, value) {
     return {component, code: value, ...options}
   }
 }
 
-function highlightWithPrism(code, language) {
-  return Prism.highlight(code, Prism.languages[language])
-}
-const prismHighlighter = highlighter(highlightWithPrism)
-
 function interactiveMarkdown(markdownString) {
   const componentBlocks = []
-  const highlightHtml = prismHighlighter('html')
-  const highlightJavaScript = prismHighlighter('javascript')
-  const highlightBash = prismHighlighter('bash')
-
-  const codeBlock = createCodeHandler(StaticCodeBlock)
-  const htmlCodeBlock = highlightHtml(codeBlock)
-  const javaScriptCodeBlock = highlightJavaScript(codeBlock)
-  const bashCodeBlock = highlightBash(codeBlock)
-  const codePreview = createCodeHandler(CodePreview)
-  const clickToRenderCodePreview = createCodeHandler(ClickToRenderCodePreview)
-
-  const pragmaHandlers = {
-    interactive(options, value) {
-      const interativeCodeBlock = options.clickToRender ?
-        clickToRenderCodePreview :
-        codePreview
-      return interativeCodeBlock(options, value)
-    },
-    callout(options, value) {
-      return {component: Callout, children: value, ...options}
-    },
-    js(options, value) {
-      return javaScriptCodeBlock(options, value)
-    },
-    bash(options, value) {
-      return bashCodeBlock(options, value)
-    },
-    html(options, value) {
-      return htmlCodeBlock(options, value)
-    },
-  }
 
   function plugin() {
     return ast => {
       visit(ast, 'code', codeNode => {
-        Object.keys(pragmaHandlers).some(pragma => {
-          if (!codeNode.lang || codeNode.lang.indexOf(pragma) !== 0) {
-            return false
-          }
-          const space = 1
-          const options = getOptions(codeNode.lang.slice(pragma.length + space))
-          componentBlocks.push(pragmaHandlers[pragma](options, codeNode.value))
-          // if it's a special code block then we need to
-          // change the node from a code block to a paragraph
-          // so when we do our replacing stuff it doesn't mess up
-          // the HTML
-          Object.assign(codeNode, {
-            type: 'paragraph',
-            children: [{type: 'text', value: 'COMPONENT_BLOCK'}],
-            lang: null,
-            value: null,
-          })
-          return true
+        const language = getLanguage(codeNode.lang)
+        const getMatchingPragma = createSupportedPragmaMatcher()
+        const specification = or(
+          matchPragmaByLanguageName(language),
+          matchPragmaByLanguageShortName(language),
+        )
+        const pragmaHandler = getMatchingPragma(specification)
+        const options = getOptions(codeNode.lang)
+
+        componentBlocks.push(pragmaHandler(options, codeNode.value))
+        // if it's a special code block then we need to
+        // change the node from a code block to a paragraph
+        // so when we do our replacing stuff it doesn't mess up
+        // the HTML
+        Object.assign(codeNode, {
+          type: 'paragraph',
+          children: [{type: 'text', value: 'COMPONENT_BLOCK'}],
+          lang: null,
+          value: null,
         })
       })
     }
@@ -121,14 +151,35 @@ function interactiveMarkdown(markdownString) {
   return markdownComponents
 }
 
-function getOptions(string) {
-  if (!string) {
+function getLanguage(languageString) {
+  if (hasOptions(languageString)) {
+    const languageStartIndex = 0
+    return languageString.substr(
+      languageStartIndex,
+      languageString.indexOf(' '),
+    )
+  }
+  return languageString
+}
+
+function hasOptions(languageString) {
+  const spaceMinimumNumberOccurrences = 1
+  return (
+    Boolean(languageString) &&
+    languageString.indexOf(' ') >= spaceMinimumNumberOccurrences
+  )
+}
+
+function getOptions(languageString) {
+  if (!hasOptions(languageString)) {
     return {}
   }
+
+  const optionString = languageString.substring(languageString.indexOf(' '))
   let options
   // we're doing this because we don't want to have to
   // write our options as JSON. Just a bit easier :)
   // eslint-disable-next-line no-eval
-  eval(`options = ${string}`)
+  eval(`options = ${optionString}`)
   return options
 }

--- a/components/interactive-markdown.js
+++ b/components/interactive-markdown.js
@@ -1,10 +1,15 @@
+import Prism from 'prismjs'
+// eslint-disable-next-line import/no-unassigned-import
+import 'prismjs/components/prism-bash'
 import React from 'react'
 import remark from 'remark'
 import remarkHtml from 'remark-html'
 import visit from 'unist-util-visit'
+import StaticCodeBlock from './static-code-block'
 import CodePreview from './code-preview'
 import Callout from './callout'
 import ClickToRender from './click-to-render'
+import highlighter from './utils/highlighter'
 import stripIndent from './utils/strip-indent'
 
 export default interactiveMarkdown
@@ -23,17 +28,48 @@ function ClickToRenderCodePreview(props) {
   )
 }
 
+function createCodeHandler(component) {
+  return function codeHandler(options, value) {
+    return {component, code: value, ...options}
+  }
+}
+
+function highlightWithPrism(code, language) {
+  return Prism.highlight(code, Prism.languages[language])
+}
+const prismHighlighter = highlighter(highlightWithPrism)
+
 function interactiveMarkdown(markdownString) {
   const componentBlocks = []
+  const highlightHtml = prismHighlighter('html')
+  const highlightJavaScript = prismHighlighter('javascript')
+  const highlightBash = prismHighlighter('bash')
+
+  const codeBlock = createCodeHandler(StaticCodeBlock)
+  const htmlCodeBlock = highlightHtml(codeBlock)
+  const javaScriptCodeBlock = highlightJavaScript(codeBlock)
+  const bashCodeBlock = highlightBash(codeBlock)
+  const codePreview = createCodeHandler(CodePreview)
+  const clickToRenderCodePreview = createCodeHandler(ClickToRenderCodePreview)
+
   const pragmaHandlers = {
     interactive(options, value) {
-      const component = options.clickToRender ?
-        ClickToRenderCodePreview :
-        CodePreview
-      return {component, code: value, ...options}
+      const interativeCodeBlock = options.clickToRender ?
+        clickToRenderCodePreview :
+        codePreview
+      return interativeCodeBlock(options, value)
     },
     callout(options, value) {
       return {component: Callout, children: value, ...options}
+    },
+    js(options, value) {
+      return javaScriptCodeBlock(options, value)
+    },
+    bash(options, value) {
+      return bashCodeBlock(options, value)
+    },
+    html(options, value) {
+      return htmlCodeBlock(options, value)
     },
   }
 

--- a/components/static-code-block.js
+++ b/components/static-code-block.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+function StaticCodeBlock({code, language}) {
+  const languageClassName = `language-${language}`
+  return (
+    <pre className={languageClassName}>
+      <code
+        className={languageClassName}
+        dangerouslySetInnerHTML={{
+          __html: code,
+        }}
+      />
+    </pre>
+  )
+}
+
+export default StaticCodeBlock

--- a/components/static-code-block.js
+++ b/components/static-code-block.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-function StaticCodeBlock({code, language}) {
+function CodeBlock({code, language}) {
   const languageClassName = `language-${language}`
   return (
     <pre className={languageClassName}>
@@ -12,6 +12,15 @@ function StaticCodeBlock({code, language}) {
       />
     </pre>
   )
+}
+
+function StaticCodeBlock({code, language, summary}) {
+  return Boolean(summary) ?
+    <details>
+      <summary>{summary}</summary>
+      <CodeBlock code={code} language={language} />
+    </details> :
+    <CodeBlock code={code} language={language} />
 }
 
 export default StaticCodeBlock

--- a/components/utils/__tests__/highlighter.js
+++ b/components/utils/__tests__/highlighter.js
@@ -1,0 +1,24 @@
+import highlighter from '../highlighter'
+
+test('a language specific code syntax highlighter can be created and used for handling code pragmas', () => {
+  const highlightFn = jest
+    .fn()
+    .mockImplementation(code => `<span>${code}</span>`)
+  const codeHandler = jest
+    .fn()
+    .mockImplementation((options, value) => ({
+      code: value,
+      component: 'a component',
+      ...options,
+    }))
+  const javaScriptCodeBlock = highlighter(highlightFn)('javascript')(
+    codeHandler,
+  )
+  const actual = javaScriptCodeBlock({option: true}, '// some code')
+  expect(actual).toEqual({
+    code: '<span>// some code</span>',
+    language: 'javascript',
+    option: true,
+    component: 'a component',
+  })
+})

--- a/components/utils/__tests__/specifications.js
+++ b/components/utils/__tests__/specifications.js
@@ -1,0 +1,27 @@
+import {or} from './../specifications'
+
+test('any matching specification will cause or to match', () => {
+  const actual = or(
+    neverMatchSpecification,
+    alwaysMatchingSpecification,
+    neverMatchSpecification,
+  )('item')
+  expect(actual).toBeTruthy()
+})
+
+test('or does not match if no specifications match', () => {
+  const actual = or(
+    neverMatchSpecification,
+    neverMatchSpecification,
+    neverMatchSpecification,
+  )('item')
+  expect(actual).toBeFalsy()
+})
+
+function alwaysMatchingSpecification() {
+  return true
+}
+
+function neverMatchSpecification() {
+  return false
+}

--- a/components/utils/highlighter.js
+++ b/components/utils/highlighter.js
@@ -1,0 +1,13 @@
+export default highlighter
+
+function highlighter(highlight) {
+  return function pragmaHighlighter(language) {
+    return function pragmaHighlightedHandler(codeHandler) {
+      return function highlightedCodeHandler(options, value) {
+        const pragmaScheme = codeHandler(options, value)
+        const code = highlight(pragmaScheme.code, language)
+        return Object.assign(pragmaScheme, {code, language})
+      }
+    }
+  }
+}

--- a/components/utils/specifications.js
+++ b/components/utils/specifications.js
@@ -1,0 +1,7 @@
+export const or = orSpecification
+
+function orSpecification(...specifications) {
+  return function specification(itemToMatch) {
+    return specifications.some(spec => spec(itemToMatch))
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "marked": "^0.3.6",
     "next": "^2.4.1",
     "polished": "^1.1.3",
+    "prismjs": "^1.6.0",
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/pages/_document/index.js
+++ b/pages/_document/index.js
@@ -60,6 +60,11 @@ export default class MyDocument extends Document {
             type="image/x-icon"
             href="/static/images/icon.png"
           />
+          <link
+            rel="stylesheet"
+            type="text/css"
+            href="/static/vendor/prism.css"
+          />
         </Head>
         <body>
           <Main />

--- a/pages/basics/content/dynamic-styles.js
+++ b/pages/basics/content/dynamic-styles.js
@@ -24,10 +24,7 @@ module.exports = {
 
   You can see a live preview of this example on [codesandbox](https://codesandbox.io/s/mZkpo0lKA).
 
-  <details>
-  <summary>Note, you can also use arrays of styles if you need:</summary>
-
-  ~~~js
+  ~~~js {summary: 'Note, you can also use arrays of styles if you need:'}
   const MyDiv = glamorous.div(
     [
       {
@@ -81,7 +78,6 @@ module.exports = {
   // />
   ~~~
 
-  </details>
   `.replace(/~/g, '`'),
   filename: __filename,
 }

--- a/pages/basics/content/install.js
+++ b/pages/basics/content/install.js
@@ -4,13 +4,13 @@ module.exports = {
   description: `
     This module is distributed via [npm](https://www.npmjs.com/) which is bundled with [node](https://nodejs.org) and should be installed as one of your project's ~dependencies~:
 
-    ~~~js
+    ~~~bash
     npm install --save glamorous
     ~~~
 
     This also depends on ~react~ and ~glamor~ so you'll need those in your project as well (if you don't already have them):
 
-    ~~~js
+    ~~~bash
     npm install --save react glamor
     ~~~
 
@@ -46,7 +46,7 @@ module.exports = {
 
     If you want to use the global:
 
-    ~~~js
+    ~~~html
     <!-- Load dependencies -->
     <script src="https://unpkg.com/react/dist/react.js"></script>
     <script src="https://unpkg.com/prop-types/prop-types.js"></script>

--- a/pages/basics/content/react-native.js
+++ b/pages/basics/content/react-native.js
@@ -4,7 +4,7 @@ module.exports = {
   description: `
     ~glamorous~ offers a version for React Native projects called ~glamorous-native~.
 
-    ~~~js
+    ~~~bash
     npm install glamorous-native --save
     ~~~
 

--- a/static/vendor/prism.css
+++ b/static/vendor/prism.css
@@ -1,0 +1,123 @@
+/* http://prismjs.com/download.html?themes=prism-okaidia&languages=markup+css+clike+javascript+bash */
+/**
+ * okaidia theme for JavaScript, CSS and HTML
+ * Loosely based on Monokai textmate theme by http://www.monokai.nl/
+ * @author ocodia
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: #f8f8f2;
+	background: none;
+	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+	border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #272822;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: slategray;
+}
+
+.token.punctuation {
+	color: #f8f8f2;
+}
+
+.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #f92672;
+}
+
+.token.boolean,
+.token.number {
+	color: #ae81ff;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #a6e22e;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+	color: #f8f8f2;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function {
+	color: #e6db74;
+}
+
+.token.keyword {
+	color: #66d9ef;
+}
+
+.token.regex,
+.token.important {
+	color: #fd971f;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+

--- a/styles/base.js
+++ b/styles/base.js
@@ -82,7 +82,7 @@ export default () => `
 
   pre code {
     background-color: initial;
-    padding: initial;
+    padding: 0;
     border-radius: initial;
     font-size: 1em;
   }


### PR DESCRIPTION
**What**:
Fixes #113. This PR adds support for syntax highlighting of additional pragmas (js, bash, html).

**Why**:
Static code blocks; such as npm install glamorous have no syntax highlighting.

**How**:
Include Prismjs (react-live component seems to utilize this, so this was chosen for consistency)
utils/highlighter.js decouples highlighting of code blocks from Prismjs and the underlying components that will render the highlighted code
functional approach: create a Prismjs specific highlighter, then Prismjs language specific highlighters, and use each of these for each of the new pragmas
update basics page for bash and html code block pragmas
This is my first PR into an OSS project! If there is any feedback you are able to give on direction, code quality, or really anything, it would be greatly appreciated.

test coverage is 100% for newly added functionality
-unfortunately, bash Prismjs support is not shipped with Prismjs and therefore requires an additional stylesheet. I do not particularly like including the stylesheet, but unsure of other options.

In hindsight, I should of simply left the other PR open to be able to continue its conversation into this one. Live and learn.