### PR TITLE
Lightened code element background color for a11y contrast

### DIFF
--- a/styles/base.js
+++ b/styles/base.js
@@ -88,7 +88,7 @@ export default () => `
   }
 
   code {
-    background-color: #eee;
+    background-color: #f6f6f6;
     padding: 2px 6px;
     border-radius: 2px;
     font-size: 0.9em;


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Lightened `code` element background color.

<!-- Why are these changes necessary? -->
**Why**:
To comply with WCAG 2.0 AA contrast ratio for accessibility

<!-- How were these changes implemented? -->
**How**:
Changed `background-color` value for `code` elements (in `/styles/base.js`) from #eee to #f6f6f6