### PR TITLE
Remove commit instructions. Closes #127

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,21 +49,6 @@ npm start "contributors.add <YOUR_GITHUB_USERNAME>"
 Follow the prompt. If you've already added yourself to the list and are making a new type of contribution, you can run
 it again and select the added contribution type.
 
-## Committing and Pushing changes
-
-This project uses [`semantic-release`][semantic-release] to do automatic releases and generate a changelog based on the
-commit history. So we follow [a convention][convention] for commit messages. Please follow this convention for your
-commit messages.
-
-You can use `commitizen` to help you to follow [the convention][convention]
-
-Once you are ready to commit the changes, please use the below commands
-
-1. `git add <files to be comitted>`
-2. `$ npm start commit`
-
-... and follow the instruction of the interactive prompt.
-
 ### opt into git hooks
 
 There are git hooks set up with this project that are automatically installed when you install dependencies. They're


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Removed section on committing and pushing from `CONTRIBUTING.md`

<!-- Why are these changes necessary? -->
**Why**:
Now that commitizen has been removed from the project (see 8abbc685c0e909f8b9c2788bf8bbe2bd703f1f5c) these instructions are no longer relevant.

<!-- How were these changes implemented? -->
**How**:
Deleted section.

<!-- feel free to add additional comments -->