### PR TITLE
docs(install): Deleting an unnecessary subtitle

### DIFF
--- a/pages/basics/content/fr/install.js
+++ b/pages/basics/content/fr/install.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Installation',
-  subtitle: 'Quelque chose',
+  subtitle: '',
   description: `
     Ce module est distribué via [npm](https://www.npmjs.com/) qui est empaqueté avec [node](https://nodejs.org) et doit être installé comme une dépendance de votre projet :
 

--- a/pages/basics/content/install.js
+++ b/pages/basics/content/install.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Installation',
-  subtitle: 'Something',
+  subtitle: '',
   description: `
     This module is distributed via [npm](https://www.npmjs.com/) which is bundled with [node](https://nodejs.org) and should be installed as one of your project's ~dependencies~:
 


### PR DESCRIPTION
**What**: Deleting an unnecessary subtitle in the installation doc

**Why**: When reviewing the documentation in French, [it was noted that the subtitle was unnecessary](https://github.com/kentcdodds/glamorous-website/pull/112#issuecomment-308445124).

**How**: Set the subtitle to empty
