### PR TITLE
Add alt tag to contributor avatars

### DIFF
--- a/components/contributors.js
+++ b/components/contributors.js
@@ -26,7 +26,10 @@ const Img = glamorous.img({
 
 const contributor = username =>
   (<Anchor key={username} href={`https://github.com/${username}`}>
-    <Img src={`https://github.com/${username}.png?size=90`} />
+    <Img
+      src={`https://github.com/${username}.png?size=90`}
+      alt={`${username}'s GitHub avatar`}
+    />
   </Anchor>)
 
 export default withContent({component: 'contributors'}, Contributors)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Added `alt` tag to contributor avatars in `contributors.js` component

<!-- Why are these changes necessary? -->
**Why**: Accessibility requirements

<!-- How were these changes implemented? -->
**How**: Alt tag with the text: `<username>'s GitHub avatar` is added to each avatar


<!-- feel free to add additional comments -->
