### PR TITLE
Change index page content to markdown

### DIFF
--- a/pages/_document/content/es/index.js
+++ b/pages/_document/content/es/index.js
@@ -1,6 +1,0 @@
-module.exports = {
-  title: 'glamorous - El estilo de los componentes React solucionado 💄',
-  tagline: 'CSS mantenible con React',
-  twitterDescription:
-    'El estilo de los componentes React solucionado con una API elegante, una huella muy pequeña y un gran rendimiento',
-}

--- a/pages/_document/content/es/index.md
+++ b/pages/_document/content/es/index.md
@@ -1,0 +1,3 @@
+---
+title: glamorous - El estilo de los componentes React solucionado 💄
+---

--- a/pages/_document/content/fr/index.js
+++ b/pages/_document/content/fr/index.js
@@ -1,6 +1,0 @@
-module.exports = {
-  title: 'glamorous - Le style des composants React est résolu 💄',
-  tagline: 'CSS Maintenable avec React',
-  twitterDescription:
-    'Le style des composants React est résolu avec une API élégante, un très faible encombrement et une excellente performance',
-}

--- a/pages/_document/content/fr/index.md
+++ b/pages/_document/content/fr/index.md
@@ -1,0 +1,3 @@
+---
+title: glamorous - Le style des composants React est résolu 💄
+---

--- a/pages/_document/content/index.js
+++ b/pages/_document/content/index.js
@@ -1,6 +1,0 @@
-module.exports = {
-  title: 'glamorous - React component styling solved 💄',
-  tagline: 'Maintainable CSS with React',
-  twitterDescription:
-    'React component styling solved with an elegant API, small footprint, and great performance',
-}

--- a/pages/_document/content/index.md
+++ b/pages/_document/content/index.md
@@ -1,0 +1,3 @@
+---
+title: glamorous - React component styling solved 💄
+---

--- a/pages/_document/index.js
+++ b/pages/_document/index.js
@@ -3,7 +3,7 @@ import Document, {Head, Main, NextScript} from 'next/document'
 import {renderStatic} from 'glamor/server'
 import GoogleAnalytics from '../../components/google-analytics'
 import ConsoleGreet from '../../components/console-greet'
-import content from './content'
+import content from './content/index.md'
 
 export default class MyDocument extends Document {
   static getInitialProps({renderPage}) {

--- a/pages/index/content/es/index.js
+++ b/pages/index/content/es/index.js
@@ -1,5 +1,0 @@
-module.exports = {
-  tagline: 'CSS mantenible con React',
-  callToAction: 'Haz clic para comenzar',
-  tryIt: 'Pruébalo',
-}

--- a/pages/index/content/es/index.md
+++ b/pages/index/content/es/index.md
@@ -1,0 +1,8 @@
+---
+title: glamorous - El estilo de los componentes React solucionado 💄
+tagline: CSS mantenible con React
+callToAction: Haz clic para comenzar
+tryIt: Pruébalo
+twitterDescription:
+  El estilo de los componentes React solucionado con una API elegante, una huella muy pequeña y un gran rendimiento
+---

--- a/pages/index/content/fr/index.js
+++ b/pages/index/content/fr/index.js
@@ -1,5 +1,0 @@
-module.exports = {
-  tagline: 'CSS Maintenable avec React',
-  callToAction: 'Cliquez ici pour commencer',
-  tryIt: 'Essayez-le',
-}

--- a/pages/index/content/fr/index.md
+++ b/pages/index/content/fr/index.md
@@ -1,0 +1,8 @@
+---
+title: glamorous - Le style des composants React est résolu 💄
+tagline: CSS Maintenable avec React
+callToAction: Cliquez ici pour commencer
+tryIt: Essayez-le
+twitterDescription:
+  Le style des composants React est résolu avec une API élégante, un très faible encombrement et une excellente performance
+---

--- a/pages/index/content/index.js
+++ b/pages/index/content/index.js
@@ -1,8 +1,0 @@
-module.exports = {
-  title: 'glamorous - React component styling solved 💄',
-  tagline: 'Maintainable CSS with React',
-  callToAction: 'Click here to get started',
-  tryIt: 'Try It',
-  twitterDescription:
-    'React component styling solved with an elegant API, small footprint, and great performance',
-}

--- a/pages/index/content/index.md
+++ b/pages/index/content/index.md
@@ -1,0 +1,8 @@
+---
+title: glamorous - React component styling solved 💄
+tagline: Maintainable CSS with React
+callToAction: Click here to get started
+tryIt: Try It
+twitterDescription:
+  React component styling solved with an elegant API, small footprint, and great performance
+---

--- a/pages/index/index.js
+++ b/pages/index/index.js
@@ -9,7 +9,7 @@ import {Button} from '../../components/styled-links'
 import Hero from '../../components/hero'
 import twitterCard from '../../components/twitter-card'
 import homePageExample from './content/home-page-example.raw'
-import content from './content'
+import content from './content/index.md'
 
 const CodePreviewWrapper = glamorous.div((props, {colors}) => ({
   position: 'relative',


### PR DESCRIPTION
**What**: Changes content from `js` to `md` for the index page. Also cleaned up the `document` content.
**Why**: To unify the way for the content, with this change every content file is in markdown.
**How**: Creating markdown files and copy pasting the text! 
Document file only includes `title` (removed `twitterDescription` and `tagline` ), since this was the only property that was being used.
Moved `title` and `twitterDescription` from translations to the index page, just like the english translation.

