### PR TITLE
fix(website): fixes issue with algolia load crashing website

### DIFF
--- a/__tests__/advanced.js
+++ b/__tests__/advanced.js
@@ -6,6 +6,8 @@ import Advanced from '../pages/advanced'
 expect.addSnapshotSerializer(serializer)
 expect.extend(matcher)
 
+global.docsearch = jest.fn(() => {})
+
 test('renders', () => {
   expect(() => mount(<Advanced />)).not.toThrow()
 })

--- a/__tests__/api.js
+++ b/__tests__/api.js
@@ -6,6 +6,8 @@ import Api from '../pages/api'
 expect.addSnapshotSerializer(serializer)
 expect.extend(matcher)
 
+global.docsearch = jest.fn(() => {})
+
 test('renders', () => {
   expect(() => mount(<Api />)).not.toThrow()
 })

--- a/__tests__/basics.js
+++ b/__tests__/basics.js
@@ -6,6 +6,8 @@ import Basics from '../pages/basics'
 expect.addSnapshotSerializer(serializer)
 expect.extend(matcher)
 
+global.docsearch = jest.fn(() => {})
+
 test('renders', () => {
   expect(() => mount(<Basics />)).not.toThrow()
 })

--- a/__tests__/examples.js
+++ b/__tests__/examples.js
@@ -6,6 +6,8 @@ import Examples from '../pages/examples'
 expect.addSnapshotSerializer(serializer)
 expect.extend(matcher)
 
+global.docsearch = jest.fn(() => {})
+
 test('renders', () => {
   expect(() => mount(<Examples />)).not.toThrow()
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -6,6 +6,8 @@ import Index from '../pages/index'
 expect.addSnapshotSerializer(serializer)
 expect.extend(matcher)
 
+global.docsearch = jest.fn(() => {})
+
 test('renders', () => {
   expect(() => mount(<Index />)).not.toThrow()
 })

--- a/__tests__/integrations.js
+++ b/__tests__/integrations.js
@@ -6,6 +6,8 @@ import Integrations from '../pages/integrations'
 expect.addSnapshotSerializer(serializer)
 expect.extend(matcher)
 
+global.docsearch = jest.fn(() => {})
+
 test('renders', () => {
   expect(() => mount(<Integrations />)).not.toThrow()
 })

--- a/components/algolia-config.js
+++ b/components/algolia-config.js
@@ -1,34 +1,33 @@
 import preval from 'preval.macro'
 import React from 'react'
-import InlineScript from './inline-script'
 
-export default AlgoliaConfig
-
-function AlgoliaConfig() {
+export function AlgoliaLink() {
   return (
-    <div>
-      <link
-        rel="stylesheet"
-        href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css"
-      />
-      <script src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" />
-      <InlineScript fn={algoliaSettings} />
-    </div>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css"
+    />
   )
 }
 
-function algoliaSettings() {
-  // eslint-disable-next-line no-var
-  var algoliaFacetFilters = preval`
-    const lang = require('./utils/locale')
-    const {fallbackLocale} = require('../config.json')
-    if (lang === fallbackLocale) {
-      module.exports = []
-    } else {
-      module.exports = [\`language:\${lang}\`]
-    }
-  `
+export function AlgoliaScript() {
+  return (
+    <script src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" />
+  )
+}
 
+// eslint-disable-next-line no-var vars-on-top
+const algoliaFacetFilters = preval`
+  const lang = require('./utils/locale')
+  const {fallbackLocale} = require('../config.json')
+  if (lang === fallbackLocale) {
+    module.exports = []
+  } else {
+    module.exports = [\`language:\${lang}\`]
+  }
+`
+
+function algoliaSettings() {
   // eslint-disable-next-line no-undef
   docsearch({
     apiKey: 'b5cb8dd730a01fb05e75f21396760fb8',
@@ -40,3 +39,5 @@ function algoliaSettings() {
     debug: false,
   })
 }
+
+export {algoliaSettings}

--- a/components/layout.js
+++ b/components/layout.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import {css, rehydrate} from 'glamor'
 import glamorous, {ThemeProvider, Div} from 'glamorous'
+import Head from 'next/head'
+import {AlgoliaLink, AlgoliaScript} from '../components/algolia-config'
 import baseStyles from '../styles/base'
 import GlobalStyles from '../styles/global-styles'
 import Nav from './nav'
@@ -55,6 +57,10 @@ function Layout({pathname, children, contributors, topNav = false}) {
   return (
     <ThemeProvider theme={GlobalStyles}>
       <Wrapper top={topNav}>
+        <Head>
+          <AlgoliaLink />
+          <AlgoliaScript />
+        </Head>
         <Nav pathname={pathname} top={topNav} />
         <Div overflow="auto" width="100%">
           {children}

--- a/components/nav.js
+++ b/components/nav.js
@@ -1,6 +1,7 @@
 import preval from 'preval.macro'
 import React from 'react'
 import glamorous from 'glamorous'
+import {algoliaSettings} from '../components/algolia-config'
 import {Anchor} from '../components/styled-links'
 import LipstickIcon from './lipstick-icon'
 import Separator from './separator'
@@ -152,6 +153,10 @@ const List = glamorous.ul(
 class Nav extends React.Component {
   state = {
     open: false,
+  }
+
+  componentDidMount() {
+    algoliaSettings()
   }
 
   handleClick = () => {

--- a/pages/_document/index.js
+++ b/pages/_document/index.js
@@ -3,7 +3,6 @@ import Document, {Head, Main, NextScript} from 'next/document'
 import {renderStatic} from 'glamor/server'
 import GoogleAnalytics from '../../components/google-analytics'
 import ConsoleGreet from '../../components/console-greet'
-import AlgoliaConfig from '../../components/algolia-config'
 import content from './content/index.md'
 
 export default class MyDocument extends Document {
@@ -42,7 +41,6 @@ export default class MyDocument extends Document {
           <NextScript />
           <GoogleAnalytics />
           <ConsoleGreet />
-          <AlgoliaConfig />
         </body>
       </html>
     )


### PR DESCRIPTION
This closes #237

**What**:

Algolia docsearch link and script moved to head to ensure availabilty

docsearch initialisation moved to componentDidMount lifecyle method of `nav.js` to ensure the element is available for it to hook onto.


**Why**:

The website was not working

**How**:

<!-- feel free to add additional comments -->

I'm not experienced with the coding style for the website, feel free to update this as you like.  Or if you give feedback happy to incorporate :).