### PR TITLE
Change url for the example with next

### DIFF
--- a/pages/integrations/content/next.md
+++ b/pages/integrations/content/next.md
@@ -4,4 +4,4 @@ contributors:
   - paulmolluzzo
 ---
 
-Here's a [deployed example](https://with-glamorous-zrqwerosse.now.sh/) of using `glamorous` with `Next.js`. See the code [here](https://github.com/zeit/next.js/tree/master/examples/with-glamorous).
+Here's a [deployed example](https://with-glamorous-wsskruvstq.now.sh/) of using `glamorous` with `Next.js`. See the code [here](https://github.com/zeit/next.js/tree/master/examples/with-glamorous).


### PR DESCRIPTION
**What**: closes #243 

**Why**: Because right we're being redirected to a 404.

**How**: Redeploy via the `now` button, and using the new url in the docs.


