### PR TITLE
Transpile process env

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -22,6 +22,9 @@ module.exports = {
     'inline-react-svg',
     './other/babel-plugin-l10n-loader',
     'babel-macros',
-    'transform-node-env-inline',
+    // the env variables in the tests aren't neededd to be transpiled
+    process.env.NODE_ENV !== 'test'
+      ? 'transform-inline-environment-variables'
+      : null,
   ].filter(Boolean),
 }

--- a/components/locale-chooser.js
+++ b/components/locale-chooser.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import glamorous from 'glamorous'
 import content from './content/locale-chooser.md'
+import getLocale from './utils/locale'
 // get flags from https://github.com/lipis/flag-icon-css/tree/master/flags/4x3
 import EnSvg from './svgs/en.svg'
 import EsSvg from './svgs/es.svg'
@@ -88,7 +89,7 @@ class LocaleChooser extends React.Component {
   state = {
     open: false,
     locales: [],
-    currentLocale: process.env.LOCALE || fallbackLocale,
+    currentLocale: getLocale(),
   }
 
   componentDidMount() {

--- a/components/twitter-card.js
+++ b/components/twitter-card.js
@@ -1,8 +1,7 @@
 import React from 'react'
 
+const locale = require('./utils/locale')()
 const {fallbackLocale} = require('../config.json')
-
-const {LOCALE: locale} = process.env
 
 function TwitterCard({
   card = 'summary_large_image',

--- a/components/utils/locale.js
+++ b/components/utils/locale.js
@@ -1,7 +1,12 @@
 const {supportedLocales, fallbackLocale} = require('../../config.json')
 
-let {LOCALE: lang} = process.env
-if (!supportedLocales.includes(lang)) {
-  lang = fallbackLocale
+function locale() {
+  const {LOCALE: lang} = process.env
+  if (supportedLocales.includes(lang)) {
+    return lang
+  }
+
+  return fallbackLocale
 }
-module.exports = lang
+
+module.exports = () => locale()

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-plugin-inline-react-svg": "^0.4.0",
     "babel-plugin-tester": "^3.3.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-node-env-inline": "0.1.1",
+    "babel-plugin-transform-inline-environment-variables": "0.1.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",


### PR DESCRIPTION
**What**: Transpile `process.env`
(Also took the opportunity to refactor the use of the current locale, see 9ecbe8aaf1f76cb314394c54a33cfff3157ea0a2)

**Why**: `LOCALE` and `USE_PREFETCH` are `undefined` at the moment

**How**: By using [`babel-plugin-transform-inline-environment-variables`](https://babeljs.io/docs/plugins/transform-inline-environment-variables/) instead of `babel-plugin-transform-node-env-inline`.


