### PR TITLE
fix(greeting): add ansi art in monospace

### DIFF
--- a/components/console-greet.js
+++ b/components/console-greet.js
@@ -32,14 +32,14 @@ function greet() {
   `
 
   /* eslint-disable */
-  console.log("%c💄 Welcome to 💄", "font-size: 24px; color: #444;")
+  console.log('%c💄 Welcome to 💄', 'font-size: 24px; color: #444;')
 
-  console.log(`%c${GLAMOROUS}`, "color: #ED5C70;")
+  console.log(`%c${GLAMOROUS}`, 'color: #ED5C70; font-family: monospace')
 
   console.log(callForContributors, gradientFont)
-  console.log(`%c${CONTRIBUTING}`, "font-size: 14px")
+  console.log(`%c${CONTRIBUTING}`, 'font-size: 14px')
 
   console.log(callToUsers, gradientFont)
-  console.log(`%c${USERS}`, "font-size: 14px")
+  console.log(`%c${USERS}`, 'font-size: 14px')
   /* eslint-enable */
 }


### PR DESCRIPTION
The Safari console doesn't use a monospace font by default, so it would look pretty wonky before this change.




<!--
IS THIS A TRANSLATION??? Great! Thanks! All PRs for translations require at least
one review from someone who is a native speaker of the language being translated.
Please @mention someone or reach out to someone on twitter to review your PR. Thanks!

Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: change the font of the greeting ansi art

<!-- Why are these changes necessary? -->
**Why**: in Safari Helvetica is used as default font 

<!-- How were these changes implemented? -->
**How**: by adding font-family: monospace

before|after
---|---
<img width="895" alt="screen shot 2017-07-31 at 11 57 23" src="https://user-images.githubusercontent.com/6270048/28772951-fc61c82e-75e7-11e7-9db9-f0c7331bd2f0.png"> |<img width="612" alt="screen shot 2017-07-31 at 11 57 08" src="https://user-images.githubusercontent.com/6270048/28772952-fc7e177c-75e7-11e7-96d7-838446b48a69.png">

This doesn't really affect other browsers since they use a monospace font by default

<!-- feel free to add additional comments -->