### PR TITLE
prevent editor from jumping

### DIFF
--- a/pages/getting-started/index.js
+++ b/pages/getting-started/index.js
@@ -102,13 +102,13 @@ class CodePreview extends Component {
         code={stripIndent(codeString).trim()}
         scope={{glamorous, ReactMarkdown: StyledReactMarkdown}}
       >
-        <StyledLiveError />
         <glamorous.Div display="flex" overflow="auto" maxHeight="86vh">
           <StyledLiveEditor onChange={this.rehighlight} />
           <RightHandSide>
             <NarrowScreenNotice>
               {pageContent.tooNarrow}
             </NarrowScreenNotice>
+            <StyledLiveError />
             <StyledLivePreview
               innerRef={node => {
                 this._preview = node


### PR DESCRIPTION
**What**:  

 Moves `<StyledLiveError />` inside of  `<RightHandSide />`.

<!-- Why are these changes necessary? -->
**Why**:

 To prevent the editor from jumping.
