### PR TITLE
Update glamorous-component-factory.md example code

### DIFF
--- a/pages/api/content/glamorous-component-factory.md
+++ b/pages/api/content/glamorous-component-factory.md
@@ -9,7 +9,7 @@ const UnstyledComp = ({ className, children }) => <div className={`${className} 
 const MyStyledComp = glamorous(UnstyledComp)({ margin: 1 })
 
 <MyStyledComp>content</MyStyledComp>
-// rendered output: <div class="<glamor-generated-class> other-class">content</div>
+// rendered output: <div class="<glamor-generated-class other-class">content</div>
 // styles applied: {margin: 1}
 ```
 ##### ...styles


### PR DESCRIPTION
{"<div class="<glamor-generated-class> other-class">content</div>" => "<div class="<glamor-generated-class other-class">content</div>"}

notice the removal of `>` after the text `glamor-generated-class`

Notice this typo while reading the documentation @ https://www.glamorous.rocks

<!--
IS THIS A TRANSLATION??? Great! Thanks! All PRs for translations require at least
one review from someone who is a native speaker of the language being translated.
Please @mention someone or reach out to someone on twitter to review your PR. Thanks!

Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:


<!-- feel free to add additional comments -->
